### PR TITLE
Use yq and helmfile build to dynamically deploy helm charts based on release name.

### DIFF
--- a/conf/patches/gke-helmfile-deployment.sh
+++ b/conf/patches/gke-helmfile-deployment.sh
@@ -1,14 +1,17 @@
 #!/bin/bash
 
 for filename in ${CONF_PATH_PREFIX}/conf/helmfile.d/*.yaml; do
-    deployment_name=$(yq r $filename releases[*].name | awk '{print $2}')
-    # deployment_name=$(grep "\- name: " ${filename} | grep -m1 -v "\- name: \"stable\"" | awk '{print $3}' | sed 's/^\"\(.\+\)\"$/\1/')
+  deployment_names=$(helmfile -f $filename build | \
+                     yq r - -- releases[*].name | awk '{print $2}')
+  for name in $deployment_names; do
+    # TODO: use retry command instead of for loop.
     retries=3
     for ((i=0; i<retries; i++)); do
-        helmfile --selector name=${deployment_name} sync
-        [[ $? -eq 0 ]] && break
-        echo "Something went wrong while deploying ${deployment_name}. Retrying in 30 seconds."
-        helm delete ${deployment_name} --purge
-        sleep 30
+      helmfile --selector name=${name} sync
+      [[ $? -eq 0 ]] && break
+      echo "Something went wrong while deploying ${name}. Retrying in 30 seconds."
+      helm delete ${name} --purge
+      sleep 30
     done
+  done
 done

--- a/conf/patches/gke-helmfile-deployment.sh
+++ b/conf/patches/gke-helmfile-deployment.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 for filename in ${CONF_PATH_PREFIX}/conf/helmfile.d/*.yaml; do
-    deployment_name=$(grep "\- name: " ${filename} | grep -m1 -v "\- name: \"stable\"" | awk '{print $3}' | sed 's/^\"\(.\+\)\"$/\1/')
+    deployment_name=$(yq r $filename releases[*].name | awk '{print $2}')
+    # deployment_name=$(grep "\- name: " ${filename} | grep -m1 -v "\- name: \"stable\"" | awk '{print $3}' | sed 's/^\"\(.\+\)\"$/\1/')
     retries=3
     for ((i=0; i<retries; i++)); do
         helmfile --selector name=${deployment_name} sync

--- a/conf/tasks/Makefile.helmfile
+++ b/conf/tasks/Makefile.helmfile
@@ -8,7 +8,13 @@ helmfile/create/all:
 	@if [ -n "${ELK_DEPLOYMENT_TOGGLE}" ]; then\
 		cp ${CONF_PATH_PREFIX}/conf/ELK_helmfiles/* ${CONF_PATH_PREFIX}/conf/helmfile.d;\
 	fi
-	${CONF_PATH_PREFIX}/conf/patches/gke-helmfile-deployment.sh
+	@for filename in ${CONF_PATH_PREFIX}/conf/helmfile.d/*.yaml; do
+		deployment_names=$(yq r $filename releases[*].name | awk '{print $2}')
+		for name in $deployment_names; do
+			retry -limit=3 -backoff=lin:10s  -- /bin/sh -c \
+				'helmfile --selector name=${name} sync ||
+				 helm delete $name --purge; exit 1'
+		done
 	@echo "Helmfile deployment finished."
 	@echo " "
 	@echo " "

--- a/conf/tasks/Makefile.helmfile
+++ b/conf/tasks/Makefile.helmfile
@@ -8,13 +8,7 @@ helmfile/create/all:
 	@if [ -n "${ELK_DEPLOYMENT_TOGGLE}" ]; then\
 		cp ${CONF_PATH_PREFIX}/conf/ELK_helmfiles/* ${CONF_PATH_PREFIX}/conf/helmfile.d;\
 	fi
-	@for filename in ${CONF_PATH_PREFIX}/conf/helmfile.d/*.yaml; do
-		deployment_names=$(yq r $filename releases[*].name | awk '{print $2}')
-		for name in $deployment_names; do
-			retry -limit=3 -backoff=lin:10s  -- /bin/sh -c \
-				'helmfile --selector name=${name} sync ||
-				 helm delete $name --purge; exit 1'
-		done
+	${CONF_PATH_PREFIX}/conf/patches/gke-helmfile-deployment.sh
 	@echo "Helmfile deployment finished."
 	@echo " "
 	@echo " "


### PR DESCRIPTION
Fixes #299 

Use `yq` and `helmfile build` to find the release name of each release of each helmfile. This is more flexible than the current script which requires any repository in the helmfile to have the name `"stable"` or else it will fail to find the deployment name.

---

Was: `grep "\- name: " ${filename} | grep -m1 -v "\- name: \"stable\"" | awk '{print $3}' | sed 's/^\"\(.\+\)\"$/\1/'` 

The second grep command is doing a hard match on `"- name: \"stable\""` to skip the repository name. However, if the repository name is not `"stable"` then the command will select the repository name to deploy instead of the release name.

Now: `helmfile -f $filename build | yq r - -- releases[*].name | awk '{print $2}'`

Using `helmfile` to set process each file with the correct templating and `yq` to read that file and select all the fields we want, we can pick the release name from the file, without doing any string matching. This function also supports multiple releases in the same helmfile, by using the `[*]`.
Using yq we can directly get every named release in a given helmfile.