### PR TITLE
upgrade the openvpn chart to latest 4.2.1.

### DIFF
--- a/conf/helmfile.d/9999.openvpn.yaml
+++ b/conf/helmfile.d/9999.openvpn.yaml
@@ -13,13 +13,13 @@ releases:
 # References:
 #   - https://github.com/helm/charts/stable/openvpn
 #
-- name: "openvpn"
-  namespace: "kube-system"
+- name: openvpn
+  namespace: kube-system
   labels:
-    chart: "openvpn"
-    component: "openvpn"
-    namespace: "kube-system"
-    vendor: "openvpn"
-    default: "true"
-  chart: 'stable/openvpn'
-  version: "1.1.0"
+    chart: openvpn
+    component: openvpn
+    namespace: kube-system
+    vendor: openvpn
+    default: true
+  chart: stable/openvpn
+  version: 4.2.1


### PR DESCRIPTION
The previous chart version is 1.1.0, which I think was intended to be the app version instead.

All the strings in the old chart are unnecessary.