### PR TITLE
Missed an environment variable update to GPU_NODE_MAX_SIZE and GPU_NODE_MIN_SIZE

### DIFF
--- a/conf/addons/cluster-autoscaler.yaml
+++ b/conf/addons/cluster-autoscaler.yaml
@@ -223,6 +223,7 @@ spec:
             - --scale-down-delay-after-delete={{ getenv "GPU_SCALE_DOWN_DELAY_AFTER_DELETE" | default "10m" }}
             - --skip-nodes-with-local-storage=false
             - --nodes={{ getenv "GPU_MIN_NODES" | default "0" }}:{{ getenv "GPU_MAX_NODES" | default "2" }}:{{ getenv "GPU_GROUP_NAME" | default "gpu-nodes" }}.{{getenv "KOPS_CLUSTER_NAME"}}
+            - --nodes={{ getenv "GPU_NODE_MIN_SIZE" | default "0" }}:{{ getenv "GPU_NODE_MAX_SIZE" | default "2" }}:{{ getenv "GPU_GROUP_NAME" | default "gpu-nodes" }}.{{getenv "KOPS_CLUSTER_NAME"}}
           env:
             - name: AWS_REGION
               value: {{ getenv "AWS_REGION" }}

--- a/conf/addons/cluster-autoscaler.yaml
+++ b/conf/addons/cluster-autoscaler.yaml
@@ -222,7 +222,6 @@ spec:
             - --scale-down-delay-after-add={{ getenv "GPU_SCALE_DOWN_DELAY_AFTER_ADD" | default "30m" }}
             - --scale-down-delay-after-delete={{ getenv "GPU_SCALE_DOWN_DELAY_AFTER_DELETE" | default "10m" }}
             - --skip-nodes-with-local-storage=false
-            - --nodes={{ getenv "GPU_MIN_NODES" | default "0" }}:{{ getenv "GPU_MAX_NODES" | default "2" }}:{{ getenv "GPU_GROUP_NAME" | default "gpu-nodes" }}.{{getenv "KOPS_CLUSTER_NAME"}}
             - --nodes={{ getenv "GPU_NODE_MIN_SIZE" | default "0" }}:{{ getenv "GPU_NODE_MAX_SIZE" | default "2" }}:{{ getenv "GPU_GROUP_NAME" | default "gpu-nodes" }}.{{getenv "KOPS_CLUSTER_NAME"}}
           env:
             - name: AWS_REGION


### PR DESCRIPTION
the AWS and GKE environment variables were unified in the menu updates, but we missed one in the `cluster-autoscaler.yaml`. This file is not used in the GKE flow, which is why we hadn't noticed.