### PR TITLE
Update default values for tf-serving

### DIFF
--- a/conf/helmfile.d/0310.tf-serving.yaml
+++ b/conf/helmfile.d/0310.tf-serving.yaml
@@ -77,7 +77,7 @@ releases:
 {{ if eq (env "CLOUD_PROVIDER" | default "aws") "aws" }}
         beta.kubernetes.io/instance-type: '{{ env "AWS_GPU_MACHINE_TYPE" | default "p2.xlarge" }}'
 {{ else }}
-        cloud.google.com/gke-accelerator: '{{ env "GCP_PREDICTION_GPU_TYPE" | default "nvidia-tesla-k80" }}'
+        cloud.google.com/gke-accelerator: '{{ env "GCP_PREDICTION_GPU_TYPE" | default "nvidia-tesla-t4" }}'
         cloud.google.com/gke-preemptible: "true"
 {{ end }}
 

--- a/conf/helmfile.d/0310.tf-serving.yaml
+++ b/conf/helmfile.d/0310.tf-serving.yaml
@@ -32,7 +32,6 @@ releases:
 
       resources:
         requests:
-          nvidia.com/gpu: 1
           cpu: 1
           memory: 3.5Gi
         limits:


### PR DESCRIPTION
* Fix default GPU type from k80 to t4. k80 is not available often.
* Remove the GPU from the resource requests, [the docs say](https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/#using-device-plugins) it only needs to be in the limits.