### PR TITLE
Upgrade redis chart to 10.5.7

### DIFF
--- a/conf/helmfile.d/0100.redis.yaml
+++ b/conf/helmfile.d/0100.redis.yaml
@@ -9,8 +9,9 @@ helmDefaults:
 
 repositories:
   # Stable repo of official helm charts
-  - name: "stable"
-    url: "https://kubernetes-charts.storage.googleapis.com"
+  - name: stable
+    url: https://kubernetes-charts.storage.googleapis.com
+
 releases:
   # Redis
   - name: redis
@@ -18,7 +19,7 @@ releases:
       chart: redis
       component: database
     chart: stable/redis
-    version: 8.1.5
+    version: 10.5.7
     namespace: deepcell
     values:
       - resources:


### PR DESCRIPTION
10.5.7 is the last chart release before they migrate the chart repository to bitnami, according to [the deprecation timeline](https://github.com/helm/charts#deprecation-timeline).

We can also un-stringify the repository name now that #300 is in stable.