### PR TITLE
Update autoscaler to 0.4.1

### DIFF
--- a/conf/helmfile.d/0210.autoscaler.yaml
+++ b/conf/helmfile.d/0210.autoscaler.yaml
@@ -13,22 +13,22 @@ releases:
 # References:
 #   - [web address of Helm chart's YAML file]
 #
-- name: "autoscaler"
-  namespace: "deepcell"
+- name: autoscaler
+  namespace: deepcell
   labels:
-    chart: "autoscaler"
-    component: "autoscaler"
-    namespace: "deepcell"
-    vendor: "vanvalenlab"
-    default: "true"
+    chart: autoscaler
+    component: autoscaler
+    namespace: deepcell
+    vendor: vanvalenlab
+    default: true
   chart: '{{ env "CHARTS_PATH" | default "/conf/charts" }}/autoscaler'
-  version: "0.1.0"
+  version: 0.1.0
   values:
     - replicas: 1
 
       image:
-        repository: "vanvalenlab/kiosk-autoscaler"
-        tag: "0.4.1"
+        repository: vanvalenlab/kiosk-autoscaler
+        tag: 0.4.1
 
       resources:
         requests:

--- a/conf/helmfile.d/0210.autoscaler.yaml
+++ b/conf/helmfile.d/0210.autoscaler.yaml
@@ -32,7 +32,7 @@ releases:
 
       resources:
         requests:
-          cpu: 100m
+          cpu: 50m
           memory: 64Mi
         # limits:
         #   cpu: 100m

--- a/conf/helmfile.d/0210.autoscaler.yaml
+++ b/conf/helmfile.d/0210.autoscaler.yaml
@@ -28,7 +28,7 @@ releases:
 
       image:
         repository: "vanvalenlab/kiosk-autoscaler"
-        tag: "0.4.0"
+        tag: "0.4.1"
 
       resources:
         requests:

--- a/conf/helmfile.d/0210.autoscaler.yaml
+++ b/conf/helmfile.d/0210.autoscaler.yaml
@@ -30,13 +30,6 @@ releases:
         repository: "vanvalenlab/kiosk-autoscaler"
         tag: "0.4.0"
 
-      serviceAccount:
-        # Specifies whether a ServiceAccount should be created
-        create: true
-        # The name of the ServiceAccount to use.
-        # If not set and create is true, a name is generated using the fullname template
-        name:
-
       resources:
         requests:
           cpu: 100m


### PR DESCRIPTION
Update to 0.4.1, which was patched for better memory use.

Reduce CPU requests to only 50m (works on high volume clusters).

Unstringify chart for aesthetics

Remove serviceAccount helmfile value as it is just the default value. nothing to override.