### PR TITLE
Update frontend to 0.4.1.

### DIFF
--- a/conf/helmfile.d/0300.frontend.yaml
+++ b/conf/helmfile.d/0300.frontend.yaml
@@ -28,7 +28,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-frontend
-        tag: 0.4.0
+        tag: 0.4.1
 
       resources:
         requests:


### PR DESCRIPTION
Includes dataLabel field in the backend API predict spec