### PR TITLE
Upgrade consumers to 0.5.1 and update models to DeepWatershed.

### DIFF
--- a/conf/charts/redis-consumer/values.yaml
+++ b/conf/charts/redis-consumer/values.yaml
@@ -37,6 +37,7 @@ env:
   EXPIRE_TIME: 3600
   GRPC_TIMEOUT: 30
   GRPC_BACKOFF: 3
+  MAX_RETRY: 0
 
   REDIS_HOST: "redis-master"
   REDIS_PORT: "6379"

--- a/conf/charts/redis-consumer/values.yaml
+++ b/conf/charts/redis-consumer/values.yaml
@@ -46,7 +46,8 @@ env:
   TF_HOST: "overwrite_this"
   TF_PORT: "sepcify_me"
   TF_TENSOR_NAME: "image"
-  TF_TENSOR_DTYPE: "DT_FLOAT"
+  TF_MAX_BATCH_SIZE: 1
+  TF_MIN_MODEL_SIZE: 128
 
   CLOUD_PROVIDER: "aws"
   AWS_REGION: "us-east-1"

--- a/conf/charts/redis-consumer/values.yaml
+++ b/conf/charts/redis-consumer/values.yaml
@@ -52,31 +52,27 @@ env:
   AWS_REGION: "us-east-1"
   GKE_COMPUTE_ZONE: "us-west1-b"
 
-  NUCLEAR_MODEL: "panoptic:3"
-  NUCLEAR_POSTPROCESS: "retinanet-semantic"
+  NUCLEAR_MODEL: "NuclearSegmentation:0"
+  NUCLEAR_POSTPROCESS: "deep_watershed"
 
-  PHASE_MODEL: "resnet50_retinanet_20190813_all_phase_512:0"
-  PHASE_POSTPROCESS: "retinanet"
+  PHASE_MODEL: "PhaseCytoSegmentation:0"
+  PHASE_POSTPROCESS: "deep_watershed"
 
-  CYTOPLASM_MODEL: "resnet50_retinanet_20190903_all_fluorescent_cyto_512:0"
-  CYTOPLASM_POSTPROCESS: "retinanet"
+  CYTOPLASM_MODEL: "FluoCytoSegmentation:0"
+  CYTOPLASM_POSTPROCESS: "deep_watershed"
 
   LABEL_DETECT_ENABLED: "false"
   LABEL_DETECT_MODEL: "LabelDetection:0"
-  LABEL_RESHAPE_SIZE: 216
-  LABEL_DETECT_SAMPLE: 3
 
   SCALE_DETECT_ENABLED: "false"
   SCALE_DETECT_MODEL: "ScaleDetection:0"
-  SCALE_RESHAPE_SIZE: 216
-  SCALE_DETECT_SAMPLE: 3
 
   DRIFT_CORRECT_ENABLED: "false"
   NORMALIZE_TRACKING: "false"
 
   TRACKING_MODEL: "tracking_model_benchmarking_757_step5_20epoch_80split_9tl:1"
-  TRACKING_SEGMENT_MODEL: "panoptic:3"
-  TRACKING_POSTPROCESS_FUNCTION: "retinanet"
+  TRACKING_SEGMENT_MODEL: "NuclearSegmentation:0"
+  TRACKING_POSTPROCESS_FUNCTION: "deep_watershed"
 
 secrets:
   AWS_ACCESS_KEY_ID: "change_me"

--- a/conf/helmfile.d/0230.segmentation-consumer.yaml
+++ b/conf/helmfile.d/0230.segmentation-consumer.yaml
@@ -65,7 +65,7 @@ releases:
         TF_HOST: "tf-serving"
         TF_PORT: 8500
         TF_TENSOR_NAME: "image"
-        TF_MAX_BATCH_SIZE: 1
+        TF_MAX_BATCH_SIZE: 64
         TF_MIN_MODEL_SIZE: 128
 
         AWS_REGION: '{{ env "AWS_REGION" | default "us-east-1" }}'

--- a/conf/helmfile.d/0230.segmentation-consumer.yaml
+++ b/conf/helmfile.d/0230.segmentation-consumer.yaml
@@ -28,7 +28,7 @@ releases:
 
       image:
         repository: "vanvalenlab/kiosk-redis-consumer"
-        tag: "0.4.4"
+        tag: "0.5.1"
 
       nameOverride: "segmentation-consumer"
 
@@ -56,6 +56,7 @@ releases:
         EMPTY_QUEUE_TIMEOUT: 5
         GRPC_TIMEOUT: 20
         GRPC_BACKOFF: 3
+        MAX_RETRY: 5
 
         REDIS_HOST: "redis"
         REDIS_PORT: 26379
@@ -64,30 +65,27 @@ releases:
         TF_HOST: "tf-serving"
         TF_PORT: 8500
         TF_TENSOR_NAME: "image"
-        TF_TENSOR_DTYPE: "DT_FLOAT"
+        TF_MAX_BATCH_SIZE: 64
+        TF_MIN_MODEL_SIZE: 128
 
         AWS_REGION: '{{ env "AWS_REGION" | default "us-east-1" }}'
         CLOUD_PROVIDER: '{{ env "CLOUD_PROVIDER" | default "aws" }}'
         GKE_COMPUTE_ZONE: '{{ env "GKE_COMPUTE_ZONE" | default "us-west1-b" }}'
 
-        NUCLEAR_MODEL: "panoptic:3"
-        NUCLEAR_POSTPROCESS: "retinanet-semantic"
+        NUCLEAR_MODEL: "NuclearSegmentation:0"
+        NUCLEAR_POSTPROCESS: "deep_watershed"
 
-        PHASE_MODEL: "resnet50_retinanet_20190813_all_phase_512:0"
-        PHASE_POSTPROCESS: "retinanet"
+        PHASE_MODEL: "PhaseCytoSegmentation:0"
+        PHASE_POSTPROCESS: "deep_watershed"
 
-        CYTOPLASM_MODEL: "resnet50_retinanet_20190903_all_fluorescent_cyto_512:0"
-        CYTOPLASM_POSTPROCESS: "retinanet"
+        CYTOPLASM_MODEL: "FluoCytoSegmentation:0"
+        CYTOPLASM_POSTPROCESS: "deep_watershed"
 
         LABEL_DETECT_ENABLED: "true"
         LABEL_DETECT_MODEL: "LabelDetection:0"
-        LABEL_RESHAPE_SIZE: 216
-        LABEL_DETECT_SAMPLE: 10
 
         SCALE_DETECT_ENABLED: "true"
         SCALE_DETECT_MODEL: "ScaleDetection:0"
-        SCALE_RESHAPE_SIZE: 216
-        SCALE_DETECT_SAMPLE: 10
 
       secrets:
         AWS_ACCESS_KEY_ID: '{{ env "AWS_ACCESS_KEY_ID" | default "NA" }}'

--- a/conf/helmfile.d/0230.segmentation-consumer.yaml
+++ b/conf/helmfile.d/0230.segmentation-consumer.yaml
@@ -11,7 +11,7 @@ releases:
 
 #
 # References:
-#   - [web address of Helm chart's YAML file]
+#   - https://github.com/vanvalenlab/kiosk-console/tree/master/conf/charts/redis-consumer
 #
 - name: segmentation-consumer
   namespace: deepcell

--- a/conf/helmfile.d/0230.segmentation-consumer.yaml
+++ b/conf/helmfile.d/0230.segmentation-consumer.yaml
@@ -65,7 +65,7 @@ releases:
         TF_HOST: "tf-serving"
         TF_PORT: 8500
         TF_TENSOR_NAME: "image"
-        TF_MAX_BATCH_SIZE: 64
+        TF_MAX_BATCH_SIZE: 1
         TF_MIN_MODEL_SIZE: 128
 
         AWS_REGION: '{{ env "AWS_REGION" | default "us-east-1" }}'

--- a/conf/helmfile.d/0230.segmentation-consumer.yaml
+++ b/conf/helmfile.d/0230.segmentation-consumer.yaml
@@ -13,24 +13,24 @@ releases:
 # References:
 #   - [web address of Helm chart's YAML file]
 #
-- name: "segmentation-consumer"
-  namespace: "deepcell"
+- name: segmentation-consumer
+  namespace: deepcell
   labels:
-    chart: "redis-consumer"
-    component: "deepcell"
-    namespace: "deepcell"
-    vendor: "vanvalenlab"
-    default: "true"
+    chart: redis-consumer
+    component: deepcell
+    namespace: deepcell
+    vendor: vanvalenlab
+    default: true
   chart: '{{ env "CHARTS_PATH" | default "/conf/charts" }}/redis-consumer'
-  version: "0.1.0"
+  version: 0.1.0
   values:
     - replicas: 1
 
       image:
-        repository: "vanvalenlab/kiosk-redis-consumer"
-        tag: "0.5.1"
+        repository: vanvalenlab/kiosk-redis-consumer
+        tag: 0.5.1
 
-      nameOverride: "segmentation-consumer"
+      nameOverride: segmentation-consumer
 
       resources:
         requests:

--- a/conf/helmfile.d/0240.segmentation-zip-consumer.yaml
+++ b/conf/helmfile.d/0240.segmentation-zip-consumer.yaml
@@ -13,22 +13,22 @@ releases:
 # References:
 #   - https://github.com/vanvalenlab/kiosk-console/tree/master/conf/charts/redis-consumer
 #
-- name: "segmentation-zip-consumer"
-  namespace: "deepcell"
+- name: segmentation-zip-consumer
+  namespace: deepcell
   labels:
-    chart: "redis-consumer"
-    component: "deepcell"
-    namespace: "deepcell"
-    vendor: "vanvalenlab"
-    default: "true"
+    chart: redis-consumer
+    component: deepcell
+    namespace: deepcell
+    vendor: vanvalenlab
+    default: true
   chart: '{{ env "CHARTS_PATH" | default "/conf/charts" }}/redis-consumer'
-  version: "0.1.0"
+  version: 0.1.0
   values:
     - replicas: 1
 
       image:
-        repository: "vanvalenlab/kiosk-redis-consumer"
-        tag: "0.4.4"
+        repository: vanvalenlab/kiosk-redis-consumer
+        tag: 0.5.1
 
       nameOverride: segmentation-zip-consumer
 

--- a/conf/helmfile.d/0240.zip-consumer.yaml
+++ b/conf/helmfile.d/0240.zip-consumer.yaml
@@ -11,7 +11,7 @@ releases:
 
 #
 # References:
-#   - [web address of Helm chart's YAML file]
+#   - https://github.com/vanvalenlab/kiosk-console/tree/master/conf/charts/redis-consumer
 #
 - name: "zip-consumer"
   namespace: "deepcell"

--- a/conf/helmfile.d/0250.tracking-consumer.yaml
+++ b/conf/helmfile.d/0250.tracking-consumer.yaml
@@ -67,7 +67,7 @@ releases:
         TF_PORT: 8500
         TF_TENSOR_NAME: "image"
         TF_MAX_BATCH_SIZE: 64
-        TF_MIN_MODEL_SIZE: 128
+        TF_MIN_MODEL_SIZE: 1
 
         AWS_REGION: '{{ env "AWS_REGION" | default "us-east-1" }}'
         CLOUD_PROVIDER: '{{ env "CLOUD_PROVIDER" | default "aws" }}'

--- a/conf/helmfile.d/0250.tracking-consumer.yaml
+++ b/conf/helmfile.d/0250.tracking-consumer.yaml
@@ -13,24 +13,24 @@ releases:
 # References:
 #   - [web address of Helm chart's YAML file]
 #
-- name: "tracking-consumer"
-  namespace: "deepcell"
+- name: tracking-consumer
+  namespace: deepcell
   labels:
-    chart: "redis-consumer"
-    component: "deepcell"
-    namespace: "deepcell"
-    vendor: "vanvalenlab"
-    default: "true"
+    chart: redis-consumer
+    component: deepcell
+    namespace: deepcell
+    vendor: vanvalenlab
+    default: true
   chart: '{{ env "CHARTS_PATH" | default "/conf/charts" }}/redis-consumer'
-  version: "0.1.0"
+  version: 0.1.0
   values:
     - replicas: 1
 
       image:
-        repository: "vanvalenlab/kiosk-redis-consumer"
-        tag: "0.5.1"
+        repository: vanvalenlab/kiosk-redis-consumer
+        tag: 0.5.1
 
-      nameOverride: "tracking-consumer"
+      nameOverride: tracking-consumer
 
       resources:
         requests:

--- a/conf/helmfile.d/0250.tracking-consumer.yaml
+++ b/conf/helmfile.d/0250.tracking-consumer.yaml
@@ -66,7 +66,7 @@ releases:
         TF_HOST: "tf-serving"
         TF_PORT: 8500
         TF_TENSOR_NAME: "image"
-        TF_MAX_BATCH_SIZE: 1
+        TF_MAX_BATCH_SIZE: 64
         TF_MIN_MODEL_SIZE: 128
 
         AWS_REGION: '{{ env "AWS_REGION" | default "us-east-1" }}'

--- a/conf/helmfile.d/0250.tracking-consumer.yaml
+++ b/conf/helmfile.d/0250.tracking-consumer.yaml
@@ -66,8 +66,8 @@ releases:
         TF_HOST: "tf-serving"
         TF_PORT: 8500
         TF_TENSOR_NAME: "image"
-        TF_MAX_BATCH_SIZE: 64
-        TF_MIN_MODEL_SIZE: 1
+        TF_MAX_BATCH_SIZE: 1
+        TF_MIN_MODEL_SIZE: 128
 
         AWS_REGION: '{{ env "AWS_REGION" | default "us-east-1" }}'
         CLOUD_PROVIDER: '{{ env "CLOUD_PROVIDER" | default "aws" }}'

--- a/conf/helmfile.d/0250.tracking-consumer.yaml
+++ b/conf/helmfile.d/0250.tracking-consumer.yaml
@@ -11,7 +11,7 @@ releases:
 
 #
 # References:
-#   - [web address of Helm chart's YAML file]
+#   - https://github.com/vanvalenlab/kiosk-console/tree/master/conf/charts/redis-consumer
 #
 - name: tracking-consumer
   namespace: deepcell

--- a/conf/helmfile.d/0250.tracking-consumer.yaml
+++ b/conf/helmfile.d/0250.tracking-consumer.yaml
@@ -28,7 +28,7 @@ releases:
 
       image:
         repository: "vanvalenlab/kiosk-redis-consumer"
-        tag: "0.4.4"
+        tag: "0.5.1"
 
       nameOverride: "tracking-consumer"
 
@@ -57,6 +57,7 @@ releases:
         EMPTY_QUEUE_TIMEOUT: 5
         GRPC_TIMEOUT: 20
         GRPC_BACKOFF: 3
+        MAX_RETRY: 5
 
         REDIS_HOST: "redis"
         REDIS_PORT: 26379
@@ -65,37 +66,34 @@ releases:
         TF_HOST: "tf-serving"
         TF_PORT: 8500
         TF_TENSOR_NAME: "image"
-        TF_TENSOR_DTYPE: "DT_FLOAT"
+        TF_MAX_BATCH_SIZE: 64
+        TF_MIN_MODEL_SIZE: 128
 
         AWS_REGION: '{{ env "AWS_REGION" | default "us-east-1" }}'
         CLOUD_PROVIDER: '{{ env "CLOUD_PROVIDER" | default "aws" }}'
         GKE_COMPUTE_ZONE: '{{ env "GKE_COMPUTE_ZONE" | default "us-west1-b" }}'
 
-        NUCLEAR_MODEL: "panoptic:3"
-        NUCLEAR_POSTPROCESS: "retinanet-semantic"
+        NUCLEAR_MODEL: "NuclearSegmentation:0"
+        NUCLEAR_POSTPROCESS: "deep_watershed"
 
-        PHASE_MODEL: "resnet50_retinanet_20190813_all_phase_512:0"
-        PHASE_POSTPROCESS: "retinanet"
+        PHASE_MODEL: "PhaseCytoSegmentation:0"
+        PHASE_POSTPROCESS: "deep_watershed"
 
-        CYTOPLASM_MODEL: "resnet50_retinanet_20190903_all_fluorescent_cyto_512:0"
-        CYTOPLASM_POSTPROCESS: "retinanet"
+        CYTOPLASM_MODEL: "FluoCytoSegmentation:0"
+        CYTOPLASM_POSTPROCESS: "deep_watershed"
 
         LABEL_DETECT_ENABLED: "true"
         LABEL_DETECT_MODEL: "LabelDetection:0"
-        LABEL_RESHAPE_SIZE: 216
-        LABEL_DETECT_SAMPLE: 10
 
         SCALE_DETECT_ENABLED: "true"
         SCALE_DETECT_MODEL: "ScaleDetection:0"
-        SCALE_RESHAPE_SIZE: 216
-        SCALE_DETECT_SAMPLE: 10
 
         DRIFT_CORRECT_ENABLED: "false"
         NORMALIZE_TRACKING: "true"
 
         TRACKING_MODEL: "tracking_model_benchmarking_757_step5_20epoch_80split_9tl:1"
-        TRACKING_SEGMENT_MODEL: "panoptic:3"
-        TRACKING_POSTPROCESS_FUNCTION: "retinanet"
+        TRACKING_SEGMENT_MODEL: "NuclearSegmentation:0"
+        TRACKING_POSTPROCESS_FUNCTION: "deep_watershed"
 
       secrets:
         AWS_ACCESS_KEY_ID: '{{ env "AWS_ACCESS_KEY_ID" | default "NA" }}'

--- a/conf/helmfile.d/0310.tf-serving.yaml
+++ b/conf/helmfile.d/0310.tf-serving.yaml
@@ -87,7 +87,7 @@ releases:
         MODEL_CONFIG_FILE: /kiosk/tf-serving/models.conf
         BATCHING_CONFIG_FILE: /kiosk/tf-serving/batching_config.txt
         ENABLE_BATCHING: "true"
-        MAX_BATCH_SIZE: 1
+        MAX_BATCH_SIZE: 128
         BATCH_TIMEOUT_MICROS: 0
         MAX_ENQUEUED_BATCHES: 512
         GRPC_CHANNEL_ARGS: ""

--- a/conf/helmfile.d/0310.tf-serving.yaml
+++ b/conf/helmfile.d/0310.tf-serving.yaml
@@ -13,22 +13,22 @@ releases:
 # References:
 #   - [web address of Helm chart's YAML file]
 #
-- name: "tf-serving"
-  namespace: "deepcell"
+- name: tf-serving
+  namespace: deepcell
   labels:
-    chart: "tf-serving"
-    component: "deepcell"
-    namespace: "deepcell"
-    vendor: "vanvalenlab"
-    default: "true"
+    chart: tf-serving
+    component: deepcell
+    namespace: deepcell
+    vendor: vanvalenlab
+    default: true
   chart: '{{ env "CHARTS_PATH" | default "/conf/charts" }}/tf-serving'
-  version: "0.1.0"
+  version: 0.1.0
   values:
     - replicas: 0
 
       image:
-        repository: "vanvalenlab/kiosk-tf-serving"
-        tag: "0.2.1"
+        repository: vanvalenlab/kiosk-tf-serving
+        tag: 0.2.1
 
       resources:
         requests:
@@ -40,15 +40,15 @@ releases:
           # memory: 8Gi
 
       tolerations:
-      - key: "nvidia.com/gpu"
-        operator: "Exists"
-        effect: "NoSchedule"
-      - key: "prediction_gpu"
-        operator: "Exists"
-        effect: "NoSchedule"
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+      - key: prediction_gpu
+        operator: Exists
+        effect: NoSchedule
 
       service:
-        type: "ClusterIP"
+        type: ClusterIP
 
         httpIngressEnabled: true
         internalHttpPort: 8501
@@ -104,4 +104,4 @@ releases:
         AWS_SECRET_ACCESS_KEY: '{{ env "AWS_SECRET_ACCESS_KEY" | default "NA" }}'
         AWS_S3_BUCKET: '{{ env "AWS_S3_BUCKET" | default "NA" }}'
         # GCLOUD_STORAGE_BUCKET: '{{ env "CLOUDSDK_BUCKET" | default "NA" }}'
-        GCLOUD_STORAGE_BUCKET: "deepcell-models"
+        GCLOUD_STORAGE_BUCKET: deepcell-models

--- a/docs/source/CUSTOM-JOB.rst
+++ b/docs/source/CUSTOM-JOB.rst
@@ -66,41 +66,33 @@ The DeepCell Kiosk uses |helm| and |helmfile| to coordinate Docker containers. T
       :label: + Show/Hide example helmfile
 
       helmDefaults:
-        args:
-          - "--wait"
-          - "--timeout=600"
-          - "--force"
-          - "--reset-values"
+        wait: true
+        timeout: 600
+        force: true
 
       releases:
-
-      ################################################################################
-      ## Custom-Consumer ################################################################
-      ################################################################################
-
       #
       # References:
-      #   - [web address of Helm chart's YAML file]
+      #   - https://github.com/vanvalenlab/kiosk-console/tree/master/conf/charts/redis-consumer
       #
-      - name: "tracking-consumer"
-        namespace: "deepcell"
+      - name: tracking-consumer
+        namespace: deepcell
         labels:
-          chart: "redis-consumer"
-          component: "deepcell"
-          namespace: "deepcell"
-          vendor: "vanvalenlab"
-          default: "true"
+          chart: redis-consumer
+          component: deepcell
+          namespace: deepcell
+          vendor: vanvalenlab
+          default: true
         chart: '{{ env "CHARTS_PATH" | default "/conf/charts" }}/redis-consumer'
-        version: "0.1.0"
+        version: 0.1.0
         values:
           - replicas: 1
 
             image:
-              repository: "vanvalenlab/kiosk-redis-consumer"
-              tag: "0.4.1"
-              pullPolicy: "Always"
+              repository: vanvalenlab/kiosk-redis-consumer
+              tag: 0.5.1
 
-            nameOverride: "tracking-consumer"
+            nameOverride: tracking-consumer
 
             resources:
               requests:
@@ -140,31 +132,27 @@ The DeepCell Kiosk uses |helm| and |helmfile| to coordinate Docker containers. T
               CLOUD_PROVIDER: '{{ env "CLOUD_PROVIDER" | default "aws" }}'
               GKE_COMPUTE_ZONE: '{{ env "GKE_COMPUTE_ZONE" | default "us-west1-b" }}'
 
-              NUCLEAR_MODEL: "panoptic:3"
-              NUCLEAR_POSTPROCESS: "retinanet-semantic"
+              NUCLEAR_MODEL: "NuclearSegmentation:0"
+              NUCLEAR_POSTPROCESS: "deep_watershed"
 
-              PHASE_MODEL: "resnet50_retinanet_20190813_all_phase_512:0"
-              PHASE_POSTPROCESS: "retinanet"
+              PHASE_MODEL: "PhaseCytoSegmentation:0"
+              PHASE_POSTPROCESS: "deep_watershed"
 
-              CYTOPLASM_MODEL:   "resnet50_retinanet_20190903_all_fluorescent_cyto_512:0"
-              CYTOPLASM_POSTPROCESS: "retinanet"
+              CYTOPLASM_MODEL:   "FluoCytoSegmentation:0"
+              CYTOPLASM_POSTPROCESS: "deep_watershed"
 
               LABEL_DETECT_ENABLED: "true"
               LABEL_DETECT_MODEL: "LabelDetection:0"
-              LABEL_RESHAPE_SIZE: 216
-              LABEL_DETECT_SAMPLE: 10
 
               SCALE_DETECT_ENABLED: "true"
               SCALE_DETECT_MODEL: "ScaleDetection:0"
-              SCALE_RESHAPE_SIZE: 216
-              SCALE_DETECT_SAMPLE: 10
 
               DRIFT_CORRECT_ENABLED: "false"
               NORMALIZE_TRACKING: "true"
 
               TRACKING_MODEL: "tracking_model_benchmarking_757_step5_20epoch_80split_9tl:1"
-              TRACKING_SEGMENT_MODEL: "panoptic:3"
-              TRACKING_POSTPROCESS_FUNCTION: "retinanet"
+              TRACKING_SEGMENT_MODEL: "NuclearSegmentation:0"
+              TRACKING_POSTPROCESS_FUNCTION: "deep_watershed"
 
             secrets:
               AWS_ACCESS_KEY_ID: '{{ env "AWS_ACCESS_KEY_ID" | default "NA" }}'


### PR DESCRIPTION
The new release of `redis-consumer` supports batching and removes the need for predefined input tensor shape and dtype information. Using the `GetModelMetadata`, each consumer can request information about the model they are about to send data to, including the input size and input dtype. This allows each model to be dynamically sliced and batched without the use of environment variables. All models have been updated to deep watershed models with pre-defined input sizes (128 for nuclear, 512 for cyto).

A future consumer release will also remove the need for named input tensors.

* Update all consumers to 0.5.1.
* Update model environment variables to DeepWatershed versions.
* Deprecate `SAMPLE`, `RESHAPE_SIZE`, and `TF_TENSOR_DTYPE` env vars by using the `GetModelMetadata` API.
* Support `TF_MAX_BATCH_SIZE` and `TF_MIN_MODEL_SIZE` for batching consumer requests to tf-serving.
* Set `MAX_RETRY` to 5 by default for consumer jobs.
* Set tf-serving `MAX_BATCH_SIZE` to 128.
* Set consumers `TF_MAX_BATCH_SIZE` to 64 (less than actual max batch size).
* Unstringify helmfiles for aesthetics.