### PR TITLE
Set no-appendfsync-on-rewrite=yes to prevent Redis latency issues during AOF fsync

### DIFF
--- a/conf/helmfile.d/0100.redis.yaml
+++ b/conf/helmfile.d/0100.redis.yaml
@@ -41,6 +41,10 @@ releases:
           appendonly yes
           # Disable RDB persistence, AOF persistence already enabled.
           save ""
+          # Prevent fsync() from being called in the main process while a
+          # BGSAVE or BGREWRITEAOF is in progress.
+          # If you have latency problems turn this to "yes". Otherwise leave it as
+          # "no" that is the safest pick from the point of view of durability.
           no-appendfsync-on-rewrite yes
 
         sysctlImage:

--- a/conf/helmfile.d/0100.redis.yaml
+++ b/conf/helmfile.d/0100.redis.yaml
@@ -31,7 +31,7 @@ releases:
 
         cluster:
           enabled: true
-          slaveCount: 2
+          slaveCount: 3
 
         sentinel:
           enabled: true

--- a/conf/helmfile.d/0100.redis.yaml
+++ b/conf/helmfile.d/0100.redis.yaml
@@ -36,6 +36,13 @@ releases:
         sentinel:
           enabled: true
 
+        configmap: |-
+          # Enable AOF https://redis.io/topics/persistence#append-only-file
+          appendonly yes
+          # Disable RDB persistence, AOF persistence already enabled.
+          save ""
+          no-appendfsync-on-rewrite yes
+
         sysctlImage:
           enabled: true
           mountHostSys: true


### PR DESCRIPTION
Fixes #315 