### PR TITLE
Install yq in install_script.sh

### DIFF
--- a/.travis/install_script.sh
+++ b/.travis/install_script.sh
@@ -28,10 +28,10 @@ echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.clou
 curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
 sudo apt-get update && sudo apt-get install google-cloud-sdk
 # Install yq
+sudo apt-get install jq -y
 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CC86BB64
-sudo add-apt-repository ppa:rmescandon/yq
-sudo apt update
-sudo apt install yq -y
+sudo add-apt-repository ppa:rmescandon/yq -y
+sudo apt-get update && sudo apt-get install yq -y
 ## prep directory structure for gcloud
 mkdir -p $CONF_PATH_PREFIX/.config/gcloud
 sudo chmod 777 $CONF_PATH_PREFIX/.config

--- a/.travis/install_script.sh
+++ b/.travis/install_script.sh
@@ -28,7 +28,10 @@ echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.clou
 curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
 sudo apt-get update && sudo apt-get install google-cloud-sdk
 # Install yq
-sudo apk add --update yq@cloudposse
+sudo apt-get install jq -y
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CC86BB64
+sudo add-apt-repository ppa:rmescandon/yq -y
+sudo apt-get update && sudo apt-get install yq -y
 ## prep directory structure for gcloud
 mkdir -p $CONF_PATH_PREFIX/.config/gcloud
 sudo chmod 777 $CONF_PATH_PREFIX/.config

--- a/.travis/install_script.sh
+++ b/.travis/install_script.sh
@@ -28,10 +28,7 @@ echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.clou
 curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
 sudo apt-get update && sudo apt-get install google-cloud-sdk
 # Install yq
-sudo apt-get install jq -y
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CC86BB64
-sudo add-apt-repository ppa:rmescandon/yq -y
-sudo apt-get update && sudo apt-get install yq -y
+sudo apk add --update yq@cloudposse
 ## prep directory structure for gcloud
 mkdir -p $CONF_PATH_PREFIX/.config/gcloud
 sudo chmod 777 $CONF_PATH_PREFIX/.config

--- a/.travis/install_script.sh
+++ b/.travis/install_script.sh
@@ -27,7 +27,12 @@ sudo apt-get install apt-transport-https ca-certificates gnupg
 echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
 sudo apt-get update && sudo apt-get install google-cloud-sdk
-## prep directory structure for gcloud	
+# Install yq
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CC86BB64
+sudo add-apt-repository ppa:rmescandon/yq
+sudo apt update
+sudo apt install yq -y
+## prep directory structure for gcloud
 mkdir -p $CONF_PATH_PREFIX/.config/gcloud
 sudo chmod 777 $CONF_PATH_PREFIX/.config
 sudo chmod 777 $CONF_PATH_PREFIX/.config/gcloud

--- a/conf/patches/gke-helmfile-deployment.sh
+++ b/conf/patches/gke-helmfile-deployment.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
 for filename in ${CONF_PATH_PREFIX}/conf/helmfile.d/*.yaml; do
+  echo $filename
   deployment_names=$(helmfile -f $filename build | \
                      yq r - -- releases[*].name | awk '{print $2}')
+  echo $deployment_names
   for name in $deployment_names; do
     # TODO: use retry command instead of for loop.
+    echo $name
     retries=3
     for ((i=0; i<retries; i++)); do
       helmfile --selector name=${name} sync

--- a/conf/patches/gke-helmfile-deployment.sh
+++ b/conf/patches/gke-helmfile-deployment.sh
@@ -2,8 +2,7 @@
 
 for filename in ${CONF_PATH_PREFIX}/conf/helmfile.d/*.yaml; do
   echo $filename
-  deployment_names=$(helmfile -f $filename build | \
-                     yq r - -- releases[*].name | awk '{print $2}')
+  deployment_names=$(helmfile -f $filename build | yq r - -- releases[*].name)
   echo $deployment_names
   for name in $deployment_names; do
     # TODO: use retry command instead of for loop.

--- a/conf/patches/gke-helmfile-deployment.sh
+++ b/conf/patches/gke-helmfile-deployment.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
 for filename in ${CONF_PATH_PREFIX}/conf/helmfile.d/*.yaml; do
-  echo $filename
-  deployment_names=$(helmfile -f $filename build | yq r - -- releases[*].name)
-  echo $deployment_names
+  deployment_names=$(helmfile -f $filename build | \
+                     yq r - -- releases[*].name | awk '{print $NF}')
   for name in $deployment_names; do
     # TODO: use retry command instead of for loop.
     echo $name

--- a/conf/patches/gke-helmfile-deployment.sh
+++ b/conf/patches/gke-helmfile-deployment.sh
@@ -5,7 +5,6 @@ for filename in ${CONF_PATH_PREFIX}/conf/helmfile.d/*.yaml; do
                      yq r - -- releases[*].name | awk '{print $NF}')
   for name in $deployment_names; do
     # TODO: use retry command instead of for loop.
-    echo $name
     retries=3
     for ((i=0; i<retries; i++)); do
       helmfile --selector name=${name} sync


### PR DESCRIPTION
`geodesic` contains a lot of tools that we use in the kiosk. We started using `yq` in our helmfile deployment in #300. This PR will install `yq` during travis tests.

The script had to be changed to accommodate differing versions of `yq` (geodesic installs version 2.4.0, while travis installs version 3.1.x) by printing the last column of the `yq` output rather than a specific index.

Integration tests succeeded: `0775c35`