### PR TITLE
Downgrade CONSUMER_MACHINE_TYPE to n1-standard-2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ ENV GCP_PREDICTION_GPU_TYPE="nvidia-tesla-t4"
 ENV GCP_TRAINING_GPU_TYPE="nvidia-tesla-v100"
 ENV GKE_MACHINE_TYPE="n1-standard-1"
 ENV GPU_MACHINE_TYPE="n1-highmem-2"
-ENV CONSUMER_MACHINE_TYPE="n1-highmem-2"
+ENV CONSUMER_MACHINE_TYPE="n1-standard-2"
 
 # Deployment config
 ENV CLOUD_PROVIDER=""

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -484,7 +484,7 @@ function configure_gke() {
   export GPU_PER_NODE=${GPU_PER_NODE:-1}
 
   # The type of node for the consumer node pools
-  export CONSUMER_MACHINE_TYPE=${CONSUMER_MACHINE_TYPE:-n1-highmem-2}
+  export CONSUMER_MACHINE_TYPE=${CONSUMER_MACHINE_TYPE:-n1-standard-2}
 
   printenv | grep -e CLOUD_PROVIDER \
     -e CLOUDSDK \


### PR DESCRIPTION
We are not making use of the extra memory available in the highmem nodes. The consumers actually use a bigger share of CPU than memory, though not so little memory to justify using a highcpu node.