### PR TITLE
Update benchmarking pod for new Deep Watershed models.

### DIFF
--- a/conf/helmfile.d/0410.benchmarking.yaml
+++ b/conf/helmfile.d/0410.benchmarking.yaml
@@ -28,7 +28,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-benchmarking
-        tag: 0.2.3
+        tag: 0.2.4
 
       resources:
         requests:
@@ -43,12 +43,14 @@ releases:
         GRAFANA_PASSWORD: prom-operator
         GRAFANA_HOST: prometheus-operator-grafana.monitoring.svc.cluster.local
         LOG_LEVEL: INFO
+        SCALE: 1
+        LABEL: ""
         API_HOST: '{{ env "CLUSTER_ADDRESS" | default "frontend" }}'
         FILE: zip100.zip
         COUNT: 100
-        MODEL: watershednuclearnofgbg41f16:0
+        MODEL: NuclearSegmentation:0
         UPLOAD_PREFIX: uploads
-        POSTPROCESS: watershed
+        POSTPROCESS: deep_watershed
         PREPROCESS: ""
         START_DELAY: 0.5
         UPDATE_INTERVAL: 15


### PR DESCRIPTION
Bump the benchmarking version to 0.2.4.

Include `SCALE` and `LABEL` as environment variables for redis-consumer >=0.4.x

Update the default model name and post-processing for deep watershed models.