### PR TITLE
Warn users if bucket's region and cluster's region do not match

### DIFF
--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -558,7 +558,7 @@ function confirm_cluster_launch() {
     local h=18
     local w=60
     local bucket_region=$(gsutil ls -L -b "gs://${CLOUDSDK_BUCKET}" | grep "Location constraint" | awk '{print tolower($NF)}')
-    if [ "$CLOUDSDK_COMPUTE_REGION" = "$bucket_region"]; then
+    if [ "$CLOUDSDK_COMPUTE_REGION" = "$bucket_region" ]; then
       local bucket_warning=("")
     else
       local bucket_warning=("\n\nThe selected region and the bucket's region do not match."

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -563,7 +563,7 @@ function confirm_cluster_launch() {
     else
       local bucket_warning=("\n\nThe selected region and the bucket's region do not match."
                             "This may cause unintended network interzone egress charges.")
-      h=$((h+4))
+      local h=22
     fi
     local notice_text=("\nYou are about to launch a cluster using the following:"
                        "\n\n    Cloud Account - ${current_account}"

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -556,11 +556,11 @@ function confirm_cluster_launch() {
          "${error_text[*]}" 9 65
   else
     local bucket_region=$(gsutil ls -L -b "gs://${CLOUDSDK_BUCKET}" | grep "Location constraint" | awk '{print tolower($NF)}')
-    if [ "$CLOUDSDK_COMPUTE_REGION" -ne "$bucket_region"]; then
+    if [ "$CLOUDSDK_COMPUTE_REGION" = "$bucket_region"]; then
+      local bucket_warning=("")
+    else
       local bucket_warning=("\n\nThe selected region and the bucket's region do not match."
                             "\nThis may cause unintended network interzone egress charges.")
-    else
-      local bucket_warning=("")
     fi
     local notice_text=("\nYou are about to launch a cluster using the following:"
                        "\n\n    Cloud Account - ${current_account}"

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -563,7 +563,7 @@ function confirm_cluster_launch() {
     else
       local bucket_warning=("\n\nThe selected region and the bucket's region do not match."
                             "This may cause unintended network interzone egress charges.")
-      local h=22
+      h=$((h+4))
     fi
     local notice_text=("\nYou are about to launch a cluster using the following:"
                        "\n\n    Cloud Account - ${current_account}"
@@ -575,7 +575,7 @@ function confirm_cluster_launch() {
                        "If the cluster does not create successfully, it may be necessary to delete resources from the cloud console."
                        "\n\nWould you like to continue?")
 
-    dialog --backtitle "${BRAND}" --title "Please Confirm" --yesno "${notice_text[*]}" h w
+    dialog --backtitle "${BRAND}" --title "Please Confirm" --yesno "${notice_text[*]}" $h $w
     response=$?
     case $response in
       0) return 0;;

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -555,12 +555,15 @@ function confirm_cluster_launch() {
     dialog --backtitle "$BRAND" --title "GKE Login Failed" --clear --msgbox \
          "${error_text[*]}" 9 65
   else
+    local h=18
+    local w=60
     local bucket_region=$(gsutil ls -L -b "gs://${CLOUDSDK_BUCKET}" | grep "Location constraint" | awk '{print tolower($NF)}')
     if [ "$CLOUDSDK_COMPUTE_REGION" = "$bucket_region"]; then
       local bucket_warning=("")
     else
       local bucket_warning=("\n\nThe selected region and the bucket's region do not match."
-                            "\nThis may cause unintended network interzone egress charges.")
+                            "This may cause unintended network interzone egress charges.")
+      h=$((h+4))
     fi
     local notice_text=("\nYou are about to launch a cluster using the following:"
                        "\n\n    Cloud Account - ${current_account}"
@@ -572,7 +575,7 @@ function confirm_cluster_launch() {
                        "If the cluster does not create successfully, it may be necessary to delete resources from the cloud console."
                        "\n\nWould you like to continue?")
 
-    dialog --backtitle "${BRAND}" --title "Please Confirm" --yesno "${notice_text[*]}" 18 60
+    dialog --backtitle "${BRAND}" --title "Please Confirm" --yesno "${notice_text[*]}" h w
     response=$?
     case $response in
       0) return 0;;

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -313,7 +313,7 @@ function configure_gke() {
   fi
 
   local bucket_region=$(gsutil ls -L -b gs://kiosk-benchmarks | grep "Location constraint" | awk '{print tolower($NF)}')
-  if [ "$CLOUDSDK_COMPUTE_REGION" -ne "$bucket_region"]
+  if [ "$CLOUDSDK_COMPUTE_REGION" -ne "$bucket_region"]; then
     local bucket_warning=("Region mismatch"
                           "\n\nThe selected region and the bucket's region do not match."
                           "\nThis may cause unintended network interzone egress charges.")

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -312,6 +312,14 @@ function configure_gke() {
     return 0
   fi
 
+  local bucket_region=$(gsutil ls -L -b gs://kiosk-benchmarks | grep "Location constraint" | awk '{print tolower($NF)}')
+  if [ "$CLOUDSDK_COMPUTE_REGION" -ne "$bucket_region"]
+    local bucket_warning=("Region mismatch"
+                          "\n\nThe selected region and the bucket's region do not match."
+                          "\nThis may cause unintended network interzone egress charges.")
+    local confirm=$(msgbox "Warning!" "${bucket_warning[*]}")
+  fi
+
   # Get information about the project from gcloud
   infobox "Loading..."
   local default_region=$(gcloud compute project-info describe \

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -312,14 +312,6 @@ function configure_gke() {
     return 0
   fi
 
-  local bucket_region=$(gsutil ls -L -b gs://kiosk-benchmarks | grep "Location constraint" | awk '{print tolower($NF)}')
-  if [ "$CLOUDSDK_COMPUTE_REGION" -ne "$bucket_region"]; then
-    local bucket_warning=("Region mismatch"
-                          "\n\nThe selected region and the bucket's region do not match."
-                          "\nThis may cause unintended network interzone egress charges.")
-    local confirm=$(msgbox "Warning!" "${bucket_warning[*]}")
-  fi
-
   # Get information about the project from gcloud
   infobox "Loading..."
   local default_region=$(gcloud compute project-info describe \
@@ -563,11 +555,19 @@ function confirm_cluster_launch() {
     dialog --backtitle "$BRAND" --title "GKE Login Failed" --clear --msgbox \
          "${error_text[*]}" 9 65
   else
+    local bucket_region=$(gsutil ls -L -b "gs://${CLOUDSDK_BUCKET}" | grep "Location constraint" | awk '{print tolower($NF)}')
+    if [ "$CLOUDSDK_COMPUTE_REGION" -ne "$bucket_region"]; then
+      local bucket_warning=("\n\nThe selected region and the bucket's region do not match."
+                            "\nThis may cause unintended network interzone egress charges.")
+    else
+      local bucket_warning=("")
+    fi
     local notice_text=("\nYou are about to launch a cluster using the following:"
                        "\n\n    Cloud Account - ${current_account}"
                        "\n    Project       - ${CLOUDSDK_CORE_PROJECT}"
                        "\n    Cluster Name  - ${CLOUDSDK_CONTAINER_CLUSTER}"
                        "\n    Bucket Name   - ${CLOUDSDK_BUCKET}"
+                       "${bucket_warning[*]}"
                        "\n\nPlease note that this process will take several minutes."
                        "If the cluster does not create successfully, it may be necessary to delete resources from the cloud console."
                        "\n\nWould you like to continue?")


### PR DESCRIPTION
Sending and receiving data from buckets outside the region will cause interzone egress charges. This PR will warn the user on the cluster creation screen if their regions do not align.

<img width="447" alt="Screen Shot 2020-04-13 at 11 05 30 AM" src="https://user-images.githubusercontent.com/7930703/79146547-6d816c00-7d77-11ea-9939-2a5a19d09c8e.png">

---

Fixes #174 