### PR TITLE
Add new menu option for default settings with 4 GPUs

### DIFF
--- a/docs/source/GETTING_STARTED.rst
+++ b/docs/source/GETTING_STARTED.rst
@@ -117,7 +117,7 @@ DeepCell Kiosk Usage
 
 * Once the Kiosk Console has started, select the ``Configure`` option for your chosen cloud provider (currently, only Google Kubernetes Engine is supported). The next screen will prompt you to authenticate your account with gcloud or to continue with a previously authenticated account. The next several screens will prompt you to select a gcloud project, name your cluster, and enter a bucket name for data storage. If you followed the Google Cloud Setup instructions from above, you should use that project and bucket name.
 
-* To complete cluster configuration, you have the option to choose between "Default" and "Advanced" configuration. The "Default" configuration option sets standard values for compute hardware and is appropriate for most users. The "Advanced" option allows users to configure each setting individually.
+* To complete cluster configuration, you have the option to choose between "Default 1 GPU", "Default 4 GPU", and "Advanced" configurations. The "Default 1 GPU" configuration option sets up a small cluster suitable for users looking to explore a sandbox. The "Default 4 GPU" option configures a cluster with 4 GPUs and nodes with more memory to handle larger inference jobs. The "Advanced" option allows users to configure each setting individually.
 
 * Once cluster configuration is complete, you will return to the home screen. There you can select the "Create" option to trigger cluster creation based on your configured values. This may take up to 10 minutes. Following successful creation, you will see a confirmation page.
 

--- a/docs/source/TROUBLESHOOTING.rst
+++ b/docs/source/TROUBLESHOOTING.rst
@@ -53,6 +53,18 @@ If that command returns an error, you may not be on Linux. If you are on Linux, 
 
 You probably just added yourself to the ``docker`` user group but haven't logged and logged back in yet.
 
+My pods are not autoscaling because the custom metrics are not updating!
+----------------------------
+Prometheus has a large memory footprint, and is liable to be OOMKilled when there are many other pods running.
+
+This can be confirmed by executing the following and inspecting the output for a Reason.
+
+.. code-block:: bash
+
+    kubectl describe node $(kubectl describe pod -n monitoring  prometheus-prometheus-operator-prometheus-0 | grep Node: | awk '{print $2}' | cut -d '/' -f1)
+
+The easiest way to resolve this issue is to upgrade the node types to something with more memory (``n1-standard-4`` seems work well for large clusters).
+
 My prediction never finishes
 ----------------------------
 A consumer should always either successfully consume a job or fail and provide an error. If a submitted prediction job never completes and the "in progress" animation is running, it is likely that the consumer pod is out of memory/CPU resources. In this case, Kubernetes responds by killing the consumer before it can complete the job. To confirm that the consumer is being ``Evicted``, drop to shell and use ``kubectl get pods``. There are a few ways to resolve a consumer being evicted due to resource constraints:

--- a/docs/source/TROUBLESHOOTING.rst
+++ b/docs/source/TROUBLESHOOTING.rst
@@ -55,15 +55,15 @@ You probably just added yourself to the ``docker`` user group but haven't logged
 
 My pods are not autoscaling because the custom metrics are not updating!
 ----------------------------
-Prometheus has a large memory footprint, and is liable to be OOMKilled when there are many other pods running.
+Prometheus has a large memory footprint and is liable to be OOMKilled when there are many other pods running.
 
-This can be confirmed by executing the following and inspecting the output for a Reason.
+This can be confirmed by executing the following and inspecting the output.
 
 .. code-block:: bash
 
     kubectl describe node $(kubectl describe pod -n monitoring  prometheus-prometheus-operator-prometheus-0 | grep Node: | awk '{print $2}' | cut -d '/' -f1)
 
-The easiest way to resolve this issue is to upgrade the node types to something with more memory (``n1-standard-4`` seems work well for large clusters).
+The easiest way to resolve this issue is to upgrade the node types to something with more memory (``n1-standard-4`` seems to work well for large clusters).
 
 My prediction never finishes
 ----------------------------

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -320,18 +320,20 @@ function configure_gke() {
                          | grep google-compute-default-region | awk '{ print $2 }')
 
   # use default settings or use the advanced menu
-  local setup_opt_value=$(dialog --clear --backtitle "${BRAND}" \
-              --title "  Configuration Options  " \
-              --menu "${header_text[*]}" 10 70 2 \
-                  "Default"     "Use default options to setup cluster" \
-                  "Advanced"    "Specify custom cluster creation options" \
-              --output-fd 1 \
-            )
+  local setup_opt_value=$(
+    dialog --clear --backtitle "${BRAND}" \
+    --title "  Configuration Options  " \
+    --menu "${header_text[*]}" 10 70 3 \
+        "Default 1 GPU"  "Use default options to setup a small cluster" \
+        "Default 4 GPU"  "Use default options to setup a large cluster" \
+        "Advanced"       "Specify custom cluster creation options" \
+    --output-fd 1 \
+  )
 
   if [ -z "$setup_opt_value" ]; then
     return 0
 
-  elif [ "$setup_opt_value" = "Default" ]; then
+  elif [ "$setup_opt_value" = "Default 1 GPU" ]; then
     # Default settings
     infobox "Loading default values..." 5 55
     export CLOUDSDK_COMPUTE_REGION=${default_region:-us-west1}
@@ -342,6 +344,18 @@ function configure_gke() {
     export GCP_TRAINING_GPU_TYPE=nvidia-tesla-v100
     export GPU_NODE_MIN_SIZE=0
     export GPU_NODE_MAX_SIZE=1
+
+  elif [ "$setup_opt_value" = "Default 4 GPU" ]; then
+    # Default settings
+    infobox "Loading default values..." 5 55
+    export CLOUDSDK_COMPUTE_REGION=${default_region:-us-west1}
+    export GKE_MACHINE_TYPE=n1-standard-4
+    export NODE_MIN_SIZE=1
+    export NODE_MAX_SIZE=60
+    export GCP_PREDICTION_GPU_TYPE=nvidia-tesla-t4
+    export GCP_TRAINING_GPU_TYPE=nvidia-tesla-v100
+    export GPU_NODE_MIN_SIZE=0
+    export GPU_NODE_MAX_SIZE=4
 
   else
     # Advanced menu

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -324,8 +324,8 @@ function configure_gke() {
     dialog --clear --backtitle "${BRAND}" \
     --title "  Configuration Options  " \
     --menu "${header_text[*]}" 10 70 3 \
-        "Default 1 GPU"  "Use default options to setup a small cluster" \
-        "Default 4 GPU"  "Use default options to setup a large cluster" \
+        "Default 1 GPU"  "The smallest cluster size possible" \
+        "Default 4 GPU"  "A robust cluster suited for larger jobs" \
         "Advanced"       "Specify custom cluster creation options" \
     --output-fd 1 \
   )

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -569,7 +569,7 @@ function confirm_cluster_launch() {
     dialog --backtitle "$BRAND" --title "GKE Login Failed" --clear --msgbox \
          "${error_text[*]}" 9 65
   else
-    local h=18
+    local h=20
     local w=60
     local bucket_region=$(gsutil ls -L -b "gs://${CLOUDSDK_BUCKET}" | grep "Location constraint" | awk '{print tolower($NF)}')
     if [ "$CLOUDSDK_COMPUTE_REGION" = "$bucket_region" ]; then
@@ -584,6 +584,8 @@ function confirm_cluster_launch() {
                        "\n    Project       - ${CLOUDSDK_CORE_PROJECT}"
                        "\n    Cluster Name  - ${CLOUDSDK_CONTAINER_CLUSTER}"
                        "\n    Bucket Name   - ${CLOUDSDK_BUCKET}"
+                       "\n    Cluster Nodes - ${GKE_MACHINE_TYPE} (${NODE_MIN_SIZE} to ${NODE_MAX_SIZE} nodes)"
+                       "\n    GPU Nodes     - ${GCP_PREDICTION_GPU_TYPE} (${GPU_NODE_MIN_SIZE} to ${GPU_NODE_MAX_SIZE} nodes)"
                        "${bucket_warning[*]}"
                        "\n\nPlease note that this process will take several minutes."
                        "If the cluster does not create successfully, it may be necessary to delete resources from the cloud console."


### PR DESCRIPTION
This PR adds a new Default configuration option for 4 GPUs. This sets the default node type to `n1-standard-4` to help remove issues where Prometheus will get OOMKilled because the node it lives on does not have enough memory.  `n1-standard-4` has shown to work for high-volume jobs with up to 8 GPUs. (Fixes #296).

The troubleshooting section has also been updated to assist users in understanding this issue and how to resolve it.

Here is what the new menu options look like:

<img width="532" alt="Screen Shot 2020-04-23 at 1 21 15 PM" src="https://user-images.githubusercontent.com/7930703/80145800-9965d400-8565-11ea-8670-567841a45902.png">
