### PR TITLE
Update zip-consumer HPA to from 1 to 2 keys per pod.

### DIFF
--- a/conf/addons/hpa.yaml
+++ b/conf/addons/hpa.yaml
@@ -82,7 +82,7 @@ spec:
         apiVersion: v1
         kind: Namespace
         name: segmentation_zip_consumer_key_ratio
-      targetValue: 1
+      targetValue: 2
 ---
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler


### PR DESCRIPTION
Majority of the time the zip consumers are waiting for jobs to be finished, so we do not really need a 1:1 ratio. This PR halves it to a 2:1 key:consumer ratio, which has been fine for the benchmarking jobs.