### PR TITLE
Bump consumers to version 0.5.2

### DIFF
--- a/conf/helmfile.d/0230.segmentation-consumer.yaml
+++ b/conf/helmfile.d/0230.segmentation-consumer.yaml
@@ -28,7 +28,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.5.1
+        tag: 0.5.2
 
       nameOverride: segmentation-consumer
 

--- a/conf/helmfile.d/0230.segmentation-consumer.yaml
+++ b/conf/helmfile.d/0230.segmentation-consumer.yaml
@@ -64,7 +64,6 @@ releases:
 
         TF_HOST: "tf-serving"
         TF_PORT: 8500
-        TF_TENSOR_NAME: "image"
         TF_MAX_BATCH_SIZE: 64
         TF_MIN_MODEL_SIZE: 128
 

--- a/conf/helmfile.d/0240.segmentation-zip-consumer.yaml
+++ b/conf/helmfile.d/0240.segmentation-zip-consumer.yaml
@@ -28,7 +28,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.5.1
+        tag: 0.5.2
 
       nameOverride: segmentation-zip-consumer
 

--- a/conf/helmfile.d/0250.tracking-consumer.yaml
+++ b/conf/helmfile.d/0250.tracking-consumer.yaml
@@ -28,7 +28,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.5.1
+        tag: 0.5.2
 
       nameOverride: tracking-consumer
 

--- a/conf/helmfile.d/0250.tracking-consumer.yaml
+++ b/conf/helmfile.d/0250.tracking-consumer.yaml
@@ -65,7 +65,6 @@ releases:
 
         TF_HOST: "tf-serving"
         TF_PORT: 8500
-        TF_TENSOR_NAME: "image"
         TF_MAX_BATCH_SIZE: 64
         TF_MIN_MODEL_SIZE: 128
 


### PR DESCRIPTION
* Bump all consumers to version 0.5.2.
* Remove all references to previously deprecated `TF_TENSOR_NAME`.