### PR TITLE
Allow users to select which zone(s) to deploy the cluster

### DIFF
--- a/conf/tasks/Makefile.gke
+++ b/conf/tasks/Makefile.gke
@@ -28,7 +28,6 @@ ifeq ($(comma), $(found))
 	multizone := 1
 endif
 gke/create/cluster:
-	@echo "Multizone = ${multizone}"
 	@echo "Creating GKE cluster in zones: ${REGION_ZONES_WITH_GPUS}..."
 	@if [ -n "${multizone}" ]; then \
 		gcloud container clusters create $(CLOUDSDK_CONTAINER_CLUSTER) \

--- a/conf/tasks/Makefile.gke
+++ b/conf/tasks/Makefile.gke
@@ -22,35 +22,18 @@ gke/destroy/project:
 	@gcloud projects delete $(CLOUDSDK_CORE_PROJECT)
 
 ## Create a new GKE cluster
-comma := ,
-found := $(findstring $(comma),$(REGION_ZONES_WITH_GPUS))
-ifeq ($(comma), $(found))
-	multizone := 1
-endif
 gke/create/cluster:
 	@echo "Creating GKE cluster in zones: ${REGION_ZONES_WITH_GPUS}..."
-	@if [ -n "${multizone}" ]; then \
-		gcloud container clusters create $(CLOUDSDK_CONTAINER_CLUSTER) \
-			--service-account=$(GCP_SERVICE_ACCOUNT) \
-			--region=$(CLOUDSDK_COMPUTE_REGION) \
-			--node-locations=$(REGION_ZONES_WITH_GPUS) \
-			--max-nodes=$(NODE_MAX_SIZE) \
-			--min-nodes=$(NODE_MIN_SIZE) \
-			--machine-type=$(GKE_MACHINE_TYPE) \
-			--cluster-version $(KUBERNETES_VERSION) \
-			--enable-autoscaling \
-			--no-enable-autoupgrade; \
-	else \
-		gcloud container clusters create $(CLOUDSDK_CONTAINER_CLUSTER) \
-			--zone=$(REGION_ZONES_WITH_GPUS) \
-			--service-account=$(GCP_SERVICE_ACCOUNT) \
-			--max-nodes=$(NODE_MAX_SIZE) \
-			--min-nodes=$(NODE_MIN_SIZE) \
-			--machine-type=$(GKE_MACHINE_TYPE) \
-			--cluster-version $(KUBERNETES_VERSION) \
-			--enable-autoscaling \
-			--no-enable-autoupgrade; \
-	fi
+	gcloud container clusters create $(CLOUDSDK_CONTAINER_CLUSTER) \
+		--service-account=$(GCP_SERVICE_ACCOUNT) \
+		--region=$(CLOUDSDK_COMPUTE_REGION) \
+		--node-locations=$(REGION_ZONES_WITH_GPUS) \
+		--max-nodes=$(NODE_MAX_SIZE) \
+		--min-nodes=$(NODE_MIN_SIZE) \
+		--machine-type=$(GKE_MACHINE_TYPE) \
+		--cluster-version $(KUBERNETES_VERSION) \
+		--enable-autoscaling \
+		--no-enable-autoupgrade
 	@echo "GKE cluster creation complete."
 	@echo " "
 	@echo " "

--- a/conf/tasks/Makefile.gke
+++ b/conf/tasks/Makefile.gke
@@ -22,12 +22,15 @@ gke/destroy/project:
 	@gcloud projects delete $(CLOUDSDK_CORE_PROJECT)
 
 ## Create a new GKE cluster
+comma := ,
+sub := Q
+subbed := $(subst $(comma),$(sub),$(REGION_ZONES_WITH_GPUS))
 gke/create/cluster:
-	ifneq (,$(findstring ,,$(REGION_ZONES_WITH_GPUS)))
-		gke/create/multizone/cluster
-	else
-		gke/create/singlezone/cluster
-	endif
+ifeq ($(sub), $(findstring $(comma),$(sub),$(REGION_ZONES_WITH_GPUS)))
+	gke/create/multizone/cluster
+else
+	gke/create/singlezone/cluster
+endif
 
 gke/create/multizone/cluster:
 	@echo "Creating GKE cluster..."

--- a/conf/tasks/Makefile.gke
+++ b/conf/tasks/Makefile.gke
@@ -23,12 +23,39 @@ gke/destroy/project:
 
 ## Create a new GKE cluster
 gke/create/cluster:
+	ifneq (,$(findstring ,,$(REGION_ZONES_WITH_GPUS)))
+		gke/create/multizone/cluster
+	else
+		gke/create/singlezone/cluster
+	endif
+
+gke/create/multizone/cluster:
 	@echo "Creating GKE cluster..."
 	@echo "Using the following command: "
+
 	gcloud container clusters create $(CLOUDSDK_CONTAINER_CLUSTER) \
+	  --zone=$(REGION_ZONES_WITH_GPUS) \
 		--service-account=$(GCP_SERVICE_ACCOUNT) \
 		--region=$(CLOUDSDK_COMPUTE_REGION) \
 		--node-locations=$(REGION_ZONES_WITH_GPUS) \
+		--max-nodes=$(NODE_MAX_SIZE) \
+		--min-nodes=$(NODE_MIN_SIZE) \
+		--machine-type=$(GKE_MACHINE_TYPE) \
+		--cluster-version $(KUBERNETES_VERSION) \
+		--enable-autoscaling \
+		--no-enable-autoupgrade
+	@echo "GKE cluster creation complete."
+	@echo " "
+	@echo " "
+
+gke/create/singlezone/cluster:
+	@echo "Creating GKE cluster..."
+	@echo "Using the following command: "
+
+	gcloud container clusters create $(CLOUDSDK_CONTAINER_CLUSTER) \
+	  --zone=$(REGION_ZONES_WITH_GPUS) \
+		--service-account=$(GCP_SERVICE_ACCOUNT) \
+		--region=$(CLOUDSDK_COMPUTE_REGION) \
 		--max-nodes=$(NODE_MAX_SIZE) \
 		--min-nodes=$(NODE_MIN_SIZE) \
 		--machine-type=$(GKE_MACHINE_TYPE) \

--- a/conf/tasks/Makefile.gke
+++ b/conf/tasks/Makefile.gke
@@ -23,37 +23,35 @@ gke/destroy/project:
 
 ## Create a new GKE cluster
 comma := ,
-sub := Q
-subbed := $(subst $(comma),$(sub),$(REGION_ZONES_WITH_GPUS))
-gke/create/cluster:
-	@echo "Creating GKE cluster..."
-	@echo "Using the following command: "
-ifeq ($(sub), $(findstring $(sub),$(subbed))))
-	@echo "Creating GKE cluster..."
-	@echo "Using the following command: "
-	gcloud container clusters create $(CLOUDSDK_CONTAINER_CLUSTER) \
-	  --zone=$(REGION_ZONES_WITH_GPUS) \
-		--service-account=$(GCP_SERVICE_ACCOUNT) \
-		--region=$(CLOUDSDK_COMPUTE_REGION) \
-		--node-locations=$(REGION_ZONES_WITH_GPUS) \
-		--max-nodes=$(NODE_MAX_SIZE) \
-		--min-nodes=$(NODE_MIN_SIZE) \
-		--machine-type=$(GKE_MACHINE_TYPE) \
-		--cluster-version $(KUBERNETES_VERSION) \
-		--enable-autoscaling \
-		--no-enable-autoupgrade
-else
-	gcloud container clusters create $(CLOUDSDK_CONTAINER_CLUSTER) \
-		--zone=$(REGION_ZONES_WITH_GPUS) \
-		--service-account=$(GCP_SERVICE_ACCOUNT) \
-		--region=$(CLOUDSDK_COMPUTE_REGION) \
-		--max-nodes=$(NODE_MAX_SIZE) \
-		--min-nodes=$(NODE_MIN_SIZE) \
-		--machine-type=$(GKE_MACHINE_TYPE) \
-		--cluster-version $(KUBERNETES_VERSION) \
-		--enable-autoscaling \
-		--no-enable-autoupgrade
+found := $(findstring $(comma),$(REGION_ZONES_WITH_GPUS))
+ifeq ($(comma), $(found))
+	multizone := 1
 endif
+gke/create/cluster:
+	@echo "Multizone = ${multizone}"
+	@echo "Creating GKE cluster in zones: ${REGION_ZONES_WITH_GPUS}..."
+	@if [ -n "${multizone}" ]; then \
+		gcloud container clusters create $(CLOUDSDK_CONTAINER_CLUSTER) \
+			--service-account=$(GCP_SERVICE_ACCOUNT) \
+			--region=$(CLOUDSDK_COMPUTE_REGION) \
+			--node-locations=$(REGION_ZONES_WITH_GPUS) \
+			--max-nodes=$(NODE_MAX_SIZE) \
+			--min-nodes=$(NODE_MIN_SIZE) \
+			--machine-type=$(GKE_MACHINE_TYPE) \
+			--cluster-version $(KUBERNETES_VERSION) \
+			--enable-autoscaling \
+			--no-enable-autoupgrade; \
+	else \
+		gcloud container clusters create $(CLOUDSDK_CONTAINER_CLUSTER) \
+			--zone=$(REGION_ZONES_WITH_GPUS) \
+			--service-account=$(GCP_SERVICE_ACCOUNT) \
+			--max-nodes=$(NODE_MAX_SIZE) \
+			--min-nodes=$(NODE_MIN_SIZE) \
+			--machine-type=$(GKE_MACHINE_TYPE) \
+			--cluster-version $(KUBERNETES_VERSION) \
+			--enable-autoscaling \
+			--no-enable-autoupgrade; \
+	fi
 	@echo "GKE cluster creation complete."
 	@echo " "
 	@echo " "

--- a/conf/tasks/Makefile.gke
+++ b/conf/tasks/Makefile.gke
@@ -26,16 +26,11 @@ comma := ,
 sub := Q
 subbed := $(subst $(comma),$(sub),$(REGION_ZONES_WITH_GPUS))
 gke/create/cluster:
-ifeq ($(sub), $(findstring $(comma),$(sub),$(REGION_ZONES_WITH_GPUS)))
-	gke/create/multizone/cluster
-else
-	gke/create/singlezone/cluster
-endif
-
-gke/create/multizone/cluster:
 	@echo "Creating GKE cluster..."
 	@echo "Using the following command: "
-
+ifeq ($(sub), $(findstring $(sub),$(subbed))))
+	@echo "Creating GKE cluster..."
+	@echo "Using the following command: "
 	gcloud container clusters create $(CLOUDSDK_CONTAINER_CLUSTER) \
 	  --zone=$(REGION_ZONES_WITH_GPUS) \
 		--service-account=$(GCP_SERVICE_ACCOUNT) \
@@ -47,16 +42,9 @@ gke/create/multizone/cluster:
 		--cluster-version $(KUBERNETES_VERSION) \
 		--enable-autoscaling \
 		--no-enable-autoupgrade
-	@echo "GKE cluster creation complete."
-	@echo " "
-	@echo " "
-
-gke/create/singlezone/cluster:
-	@echo "Creating GKE cluster..."
-	@echo "Using the following command: "
-
+else
 	gcloud container clusters create $(CLOUDSDK_CONTAINER_CLUSTER) \
-	  --zone=$(REGION_ZONES_WITH_GPUS) \
+		--zone=$(REGION_ZONES_WITH_GPUS) \
 		--service-account=$(GCP_SERVICE_ACCOUNT) \
 		--region=$(CLOUDSDK_COMPUTE_REGION) \
 		--max-nodes=$(NODE_MAX_SIZE) \
@@ -65,6 +53,7 @@ gke/create/singlezone/cluster:
 		--cluster-version $(KUBERNETES_VERSION) \
 		--enable-autoscaling \
 		--no-enable-autoupgrade
+endif
 	@echo "GKE cluster creation complete."
 	@echo " "
 	@echo " "

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -494,7 +494,7 @@ function configure_gke() {
   fi
   msgbox "debug zone" "\n${default}\n${REGION_ZONES_WITH_GPUS}\n${valid_zones[*]}" 10 55
   export REGION_ZONES_WITH_GPUS=$(radiobox_from_array "Google Cloud" \
-                                  $default_zone "${message}" ${valid_zones})
+                                  $default_zone "${message}" $(echo "${valid_zones[*]}" | sort -u))
 
   if [ "$REGION_ZONES_WITH_GPUS" = "" ]; then
     return 0

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -487,7 +487,7 @@ function configure_gke() {
   fi
 
   valid_zones+=("Multizone")  # add an "All of the above option"
-  local message=("Select a single zone to deploy in, or deploy a multizone cluster.")
+  local message=("Deploy the a single- or multi-zone cluster.")
   local default="${REGION_ZONES_WITH_GPUS:-Multizone}"
   if [[ $string == *","* ]]; then
     default="Multizone"

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -492,9 +492,9 @@ function configure_gke() {
   if [ $default_zone == *","* ]; then
     default_zone="Multizone"
   fi
-
+  local zone_choices=$(for i in ${valid_zones[@]}; do echo $i; done)
   export REGION_ZONES_WITH_GPUS=$(radiobox_from_array "Google Cloud" \
-                                  $default_zone "${message}" $(for i in ${valid_zones[@]}; do echo $i; done))
+                                  $default_zone "${message}" "${zone_choices}")
 
   if [ "$REGION_ZONES_WITH_GPUS" = "" ]; then
     return 0

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -486,7 +486,6 @@ function configure_gke() {
   fi
 
   valid_zones+=("Multizone")  # add an "All of the above option"
-  if
   local message=("Select a single zone to deploy in, or deploy a multizone cluster.")
   export REGION_ZONES_WITH_GPUS=$(radiobox_from_array "Google Cloud" \
                                   "Multizone" "${message}" "${valid_zones}")

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -486,15 +486,15 @@ function configure_gke() {
     return 0
   fi
 
-  valid_zones+=('Multizone')  # add an "All of the above option"
+  # valid_zones+=('Multizone')  # add an "All of the above option"
   local message="Deploy a single- or multi-zone cluster."
   local default_zone="${REGION_ZONES_WITH_GPUS:-Multizone}"
-  if [[ $default_zone == *","* ]]; then
+  if [ $default_zone == *","* ]; then
     default_zone="Multizone"
   fi
   msgbox "debug zone" "\n${default}\n${REGION_ZONES_WITH_GPUS}\n${valid_zones[*]}" 10 55
   export REGION_ZONES_WITH_GPUS=$(radiobox_from_array "Google Cloud" \
-                                  "$default_zone" "${message}" "${valid_zones}")
+                                  $default_zone "${message}" "${valid_zones}")
 
   if [ "$REGION_ZONES_WITH_GPUS" = "" ]; then
     return 0

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -494,7 +494,7 @@ function configure_gke() {
   fi
   msgbox "debug zone" "\n${default}\n${REGION_ZONES_WITH_GPUS}\n${valid_zones[*]}" 10 55
   export REGION_ZONES_WITH_GPUS=$(radiobox_from_array "Google Cloud" \
-                                  $default_zone "${message}" $(echo "${valid_zones[*]}" | sort -u))
+                                  "$default_zone" "${message}" "${valid_zones}")
 
   if [ "$REGION_ZONES_WITH_GPUS" = "" ]; then
     return 0

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -494,13 +494,14 @@ function configure_gke() {
   fi
   msgbox "debug zone" "\n${default}\n${REGION_ZONES_WITH_GPUS}\n${valid_zones[*]}" 10 55
   export REGION_ZONES_WITH_GPUS=$(radiobox_from_array "Google Cloud" \
-                                  $default_zone "${message}" "${valid_zones}")
+                                  $default_zone "${message}" "${valid_zones[*]}")
+
 
   if [ "$REGION_ZONES_WITH_GPUS" = "" ]; then
     return 0
   elif [ "$REGION_ZONES_WITH_GPUS" = "Multizone" ]; then
     export REGION_ZONES_WITH_GPUS=$(IFS=','; echo "${valid_zones[*]}"; IFS=$' \t\n')
-    unset valid_zones[${#valid_zones[@]}-1] # remove "Multizone" from list
+    # unset valid_zones[${#valid_zones[@]}-1] # remove "Multizone" from list
   fi
 
   # TODO: del this msgbox

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -492,6 +492,8 @@ function configure_gke() {
   if [[ $string == *","* ]]; then
     default="Multizone"
   fi
+  #TODO del msgbox
+  msgbox "debug zone" "\n${default}\n${REGION_ZONES_WITH_GPUS}\n${valid_zones[*]}}" 7 55
   export REGION_ZONES_WITH_GPUS=$(radiobox_from_array "Google Cloud" \
                                   "${default}" "${message[*]}" "${valid_zones}")
 

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -486,7 +486,6 @@ function configure_gke() {
   fi
 
   valid_zones+=("Multizone")  # add an "All of the above option"
-  local default_zone=$REGION_ZONES_WITH_GPUS
   if
   local message=("Select a single zone to deploy in, or deploy a multizone cluster.")
   export REGION_ZONES_WITH_GPUS=$(radiobox_from_array "Google Cloud" \

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -492,10 +492,9 @@ function configure_gke() {
   if [ $default_zone == *","* ]; then
     default_zone="Multizone"
   fi
-  msgbox "debug zone" "\n${default}\n${REGION_ZONES_WITH_GPUS}\n${valid_zones[*]}" 10 55
-  export REGION_ZONES_WITH_GPUS=$(radiobox_from_array "Google Cloud" \
-                                  $default_zone "${message}" "${valid_zones[@]}")
 
+  export REGION_ZONES_WITH_GPUS=$(radiobox_from_array "Google Cloud" \
+                                  $default_zone "${message}" $(for i in ${valid_zones[@]}; do echo $i; done))
 
   if [ "$REGION_ZONES_WITH_GPUS" = "" ]; then
     return 0
@@ -503,9 +502,6 @@ function configure_gke() {
     export REGION_ZONES_WITH_GPUS=$(IFS=','; echo "${valid_zones[*]}"; IFS=$' \t\n')
     unset valid_zones[${#valid_zones[@]}-1] # remove "Multizone" from list
   fi
-
-  # TODO: del this msgbox
-  msgbox "REGION_ZONES_WITH_GPUS" "${REGION_ZONES_WITH_GPUS}\n${valid_zones[*]}." 7 55
 
   msgbox "Configuration Complete!" "\nThe cluster is now available for creation." 7 55
 

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -494,13 +494,16 @@ function configure_gke() {
   fi
   export REGION_ZONES_WITH_GPUS=$(radiobox_from_array "Google Cloud" \
                                   "${default}" "${message[*]}" "${valid_zones}")
-  unset valid_zones[${#valid_zones[@]}-1] # remove "Multizone" from list
 
   if [ "$REGION_ZONES_WITH_GPUS" = "" ]; then
     return 0
   elif [ "$REGION_ZONES_WITH_GPUS" = "Multizone" ]; then
     export REGION_ZONES_WITH_GPUS=$(IFS=','; echo "${valid_zones[*]}"; IFS=$' \t\n')
+    unset valid_zones[${#valid_zones[@]}-1] # remove "Multizone" from list
   fi
+
+  # TODO: del this msgbox
+  msgbox "REGION_ZONES_WITH_GPUS: ${REGION_ZONES_WITH_GPUS}." 7 55
 
   msgbox "Configuration Complete!" "\nThe cluster is now available for creation." 7 55
 

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -486,7 +486,7 @@ function configure_gke() {
     return 0
   fi
 
-  # valid_zones+=('Multizone')  # add an "All of the above option"
+  valid_zones+=('Multizone')  # add an "All of the above option"
   local message="Deploy a single- or multi-zone cluster."
   local default_zone="${REGION_ZONES_WITH_GPUS:-Multizone}"
   if [ $default_zone == *","* ]; then
@@ -494,14 +494,14 @@ function configure_gke() {
   fi
   msgbox "debug zone" "\n${default}\n${REGION_ZONES_WITH_GPUS}\n${valid_zones[*]}" 10 55
   export REGION_ZONES_WITH_GPUS=$(radiobox_from_array "Google Cloud" \
-                                  $default_zone "${message}" "${valid_zones[*]}")
+                                  $default_zone "${message}" "${valid_zones[@]}")
 
 
   if [ "$REGION_ZONES_WITH_GPUS" = "" ]; then
     return 0
   elif [ "$REGION_ZONES_WITH_GPUS" = "Multizone" ]; then
     export REGION_ZONES_WITH_GPUS=$(IFS=','; echo "${valid_zones[*]}"; IFS=$' \t\n')
-    # unset valid_zones[${#valid_zones[@]}-1] # remove "Multizone" from list
+    unset valid_zones[${#valid_zones[@]}-1] # remove "Multizone" from list
   fi
 
   # TODO: del this msgbox

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -477,6 +477,7 @@ function configure_gke() {
     fi
   done
 
+  # Allow the user to select one or all the zones to deploy
   if [ ${#valid_zones[@]} -lt 1 ]; then
     local message=("There are no zones in your region with the specified GPU type(s)."
                    "\n\n"
@@ -487,8 +488,12 @@ function configure_gke() {
 
   valid_zones+=("Multizone")  # add an "All of the above option"
   local message=("Select a single zone to deploy in, or deploy a multizone cluster.")
+  local default="${REGION_ZONES_WITH_GPUS:-Multizone}"
+  if [[ $string == *","* ]]; then
+    default="Multizone"
+  fi
   export REGION_ZONES_WITH_GPUS=$(radiobox_from_array "Google Cloud" \
-                                  "Multizone" "${message}" "${valid_zones}")
+                                  "${default}" "${message}" "${valid_zones}")
   unset valid_zones[${#valid_zones[@]}-1] # remove "Multizone" from list
 
   if [ "$REGION_ZONES_WITH_GPUS" = "" ]; then

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -495,7 +495,7 @@ function configure_gke() {
   #TODO del msgbox
   msgbox "debug zone" "\n${default}\n${REGION_ZONES_WITH_GPUS}\n${valid_zones[*]}" 10 55
   export REGION_ZONES_WITH_GPUS=$(radiobox_from_array "Google Cloud" \
-                                  $default_zone "${message[*]}" "${valid_zones}")
+                                  $default_zone "${message}" "${valid_zones}")
 
   if [ "$REGION_ZONES_WITH_GPUS" = "" ]; then
     return 0

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -494,7 +494,7 @@ function configure_gke() {
   fi
   msgbox "debug zone" "\n${default}\n${REGION_ZONES_WITH_GPUS}\n${valid_zones[*]}" 10 55
   export REGION_ZONES_WITH_GPUS=$(radiobox_from_array "Google Cloud" \
-                                  $default_zone "${message}" "${valid_zones}")
+                                  $default_zone "${message}" ${valid_zones})
 
   if [ "$REGION_ZONES_WITH_GPUS" = "" ]; then
     return 0

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -489,7 +489,7 @@ function configure_gke() {
   fi
 
   local message="Deploy a single- or multi-zone cluster."
-  local default_zone="${REGION_ZONES_WITH_GPUS:-$valid_zones[0]}"
+  local default_zone="${REGION_ZONES_WITH_GPUS:-${valid_zones[0]}}"
   if [[ $default_zone == *","* ]]; then
     default_zone="Multizone"
   fi

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -493,7 +493,6 @@ function configure_gke() {
     default_zone="Multizone"
   fi
   local zone_choices=$(for i in ${valid_zones[@]}; do echo $i; done)
-  zone_choices=$(echo "${zone_choices[*]}" | sort -u)
   export REGION_ZONES_WITH_GPUS=$(radiobox_from_array "Google Cloud" \
                                   $default_zone "${message}" "${zone_choices}")
 

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -489,7 +489,7 @@ function configure_gke() {
   fi
 
   local message="Deploy a single- or multi-zone cluster."
-  local default_zone="${REGION_ZONES_WITH_GPUS:-${valid_zones[0]}}"
+  local default_zone="${REGION_ZONES_WITH_GPUS:-$valid_zones[${#valid_zones[@]}-1]}"
   if [[ $default_zone == *","* ]]; then
     default_zone="Multizone"
   fi

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -493,7 +493,7 @@ function configure_gke() {
     default="Multizone"
   fi
   export REGION_ZONES_WITH_GPUS=$(radiobox_from_array "Google Cloud" \
-                                  "${default}" "${message}" "${valid_zones}")
+                                  "${default}" "${message[*]}" "${valid_zones}")
   unset valid_zones[${#valid_zones[@]}-1] # remove "Multizone" from list
 
   if [ "$REGION_ZONES_WITH_GPUS" = "" ]; then

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -489,7 +489,7 @@ function configure_gke() {
   fi
 
   local message="Deploy a single- or multi-zone cluster."
-  local default_zone="${REGION_ZONES_WITH_GPUS:-$valid_zones[${#valid_zones[@]}-1]}"
+  local default_zone="${REGION_ZONES_WITH_GPUS:-$valid_zones[0]}"
   if [[ $default_zone == *","* ]]; then
     default_zone="Multizone"
   fi

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -487,15 +487,15 @@ function configure_gke() {
   fi
 
   valid_zones+=('Multizone')  # add an "All of the above option"
-  local message=("Deploy the a single- or multi-zone cluster.")
-  local default="${REGION_ZONES_WITH_GPUS:-Multizone}"
-  if [[ $string == *","* ]]; then
-    default="Multizone"
+  local message=("Deploy a single- or multi-zone cluster.")
+  local default_zone="${REGION_ZONES_WITH_GPUS:-Multizone}"
+  if [[ $default_zone == *","* ]]; then
+    default_zone="Multizone"
   fi
   #TODO del msgbox
-  msgbox "debug zone" "\n${default}\n${REGION_ZONES_WITH_GPUS}\n${valid_zones[*]}}" 7 55
+  msgbox "debug zone" "\n${default}\n${REGION_ZONES_WITH_GPUS}\n${valid_zones[*]}" 10 55
   export REGION_ZONES_WITH_GPUS=$(radiobox_from_array "Google Cloud" \
-                                  "${default}" "${message[*]}" "${valid_zones}")
+                                  $default_zone "${message[*]}" "${valid_zones}")
 
   if [ "$REGION_ZONES_WITH_GPUS" = "" ]; then
     return 0

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -487,12 +487,11 @@ function configure_gke() {
   fi
 
   valid_zones+=('Multizone')  # add an "All of the above option"
-  local message=("Deploy a single- or multi-zone cluster.")
+  local message="Deploy a single- or multi-zone cluster."
   local default_zone="${REGION_ZONES_WITH_GPUS:-Multizone}"
   if [[ $default_zone == *","* ]]; then
     default_zone="Multizone"
   fi
-  #TODO del msgbox
   msgbox "debug zone" "\n${default}\n${REGION_ZONES_WITH_GPUS}\n${valid_zones[*]}" 10 55
   export REGION_ZONES_WITH_GPUS=$(radiobox_from_array "Google Cloud" \
                                   $default_zone "${message}" "${valid_zones}")

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -486,7 +486,7 @@ function configure_gke() {
     return 0
   fi
 
-  valid_zones+=("Multizone")  # add an "All of the above option"
+  valid_zones+=('Multizone')  # add an "All of the above option"
   local message=("Deploy the a single- or multi-zone cluster.")
   local default="${REGION_ZONES_WITH_GPUS:-Multizone}"
   if [[ $string == *","* ]]; then

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -505,7 +505,7 @@ function configure_gke() {
   fi
 
   # TODO: del this msgbox
-  msgbox "REGION_ZONES_WITH_GPUS" "${REGION_ZONES_WITH_GPUS}." 7 55
+  msgbox "REGION_ZONES_WITH_GPUS" "${REGION_ZONES_WITH_GPUS}\n${valid_zones[*]}." 7 55
 
   msgbox "Configuration Complete!" "\nThe cluster is now available for creation." 7 55
 

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -392,10 +392,10 @@ function configure_gke() {
     fi
 
     infobox "Loading..."
-      local gpus_in_region=$(gcloud compute accelerator-types list \
-                             --format "value(name)" \
-                             --filter "ZONE : ${CLOUDSDK_COMPUTE_REGION}" \
-                             | sort -u)
+    local gpus_in_region=$(gcloud compute accelerator-types list \
+                           --format "value(name)" \
+                           --filter "ZONE : ${CLOUDSDK_COMPUTE_REGION}" \
+                           | sort -u)
     local default_prediction_gpu=${GCP_PREDICTION_GPU_TYPE:-nvidia-tesla-t4}
     # local message="Choose a GPU for prediction (not training) from the GPU types available in your region:"
     local message="Choose a GPU from the types available in your region:"

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -493,6 +493,7 @@ function configure_gke() {
     default_zone="Multizone"
   fi
   local zone_choices=$(for i in ${valid_zones[@]}; do echo $i; done)
+  zone_choices=$(echo "${zone_choices[*]}" | sort -u)
   export REGION_ZONES_WITH_GPUS=$(radiobox_from_array "Google Cloud" \
                                   $default_zone "${message}" "${zone_choices}")
 

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -484,12 +484,12 @@ function configure_gke() {
                    "Please re-configure with a different region/GPU type combination.")
     msgbox "Error!" "${message[*]}"
     return 0
+  elif [ ${#valid_zones[@]} -gt 1 ]; then
+    valid_zones+=('Multizone')  # add an "All of the above option"
   fi
 
-  valid_zones+=('Multizone')  # add an "All of the above option"
   local message="Deploy a single- or multi-zone cluster."
-  local default_zone="${REGION_ZONES_WITH_GPUS:-Multizone}"
-  if [ $default_zone == *","* ]; then
+  local default_zone="${REGION_ZONES_WITH_GPUS:-$valid_zones[${#valid_zones[@]}-1]}"
     default_zone="Multizone"
   fi
   local zone_choices=$(for i in ${valid_zones[@]}; do echo $i; done)

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -503,7 +503,7 @@ function configure_gke() {
   fi
 
   # TODO: del this msgbox
-  msgbox "REGION_ZONES_WITH_GPUS: ${REGION_ZONES_WITH_GPUS}." 7 55
+  msgbox "REGION_ZONES_WITH_GPUS" "${REGION_ZONES_WITH_GPUS}." 7 55
 
   msgbox "Configuration Complete!" "\nThe cluster is now available for creation." 7 55
 

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -499,8 +499,8 @@ function configure_gke() {
   if [ "$REGION_ZONES_WITH_GPUS" = "" ]; then
     return 0
   elif [ "$REGION_ZONES_WITH_GPUS" = "Multizone" ]; then
-    export REGION_ZONES_WITH_GPUS=$(IFS=','; echo "${valid_zones[*]}"; IFS=$' \t\n')
     unset valid_zones[${#valid_zones[@]}-1] # remove "Multizone" from list
+    export REGION_ZONES_WITH_GPUS=$(IFS=','; echo "${valid_zones[*]}"; IFS=$' \t\n')
   fi
 
   msgbox "Configuration Complete!" "\nThe cluster is now available for creation." 7 55

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -456,7 +456,7 @@ function configure_gke() {
   # If GPUs are not available in at least 2 zones, the user must restart.
   local available_zones=$(gcloud compute zones list \
                           --filter "status = UP AND region = ${CLOUDSDK_COMPUTE_REGION}" \
-                          --format "value(name)")
+                          --format "value(name)" | sort -u)
 
   # locate the zones for all GPU node pools
   local prediction_gpu_zones=$(gcloud compute accelerator-types list \

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -490,6 +490,7 @@ function configure_gke() {
 
   local message="Deploy a single- or multi-zone cluster."
   local default_zone="${REGION_ZONES_WITH_GPUS:-$valid_zones[${#valid_zones[@]}-1]}"
+  if [[ $default_zone == *","* ]]; then
     default_zone="Multizone"
   fi
   local zone_choices=$(for i in ${valid_zones[@]}; do echo $i; done)


### PR DESCRIPTION
Single-zone clusters are (now?) supported in GKE, but the Kiosk will automatically deploy a multi-zone cluster into all available zones. Instead, this PR provides a final menu option that allows the user to select an individual zone by name, or the "Multizone" option (default), which uses the current behavior.

---

<img width="631" alt="zone select menu screenshot" src="https://user-images.githubusercontent.com/7930703/82247992-3fee8c00-98fc-11ea-9de8-0aea9d369ed6.png">
