### PR TITLE
Bump benchmarking version to 0.3.1

### DIFF
--- a/conf/helmfile.d/0410.benchmarking.yaml
+++ b/conf/helmfile.d/0410.benchmarking.yaml
@@ -28,7 +28,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-benchmarking
-        tag: 0.3.0
+        tag: 0.3.1
 
       resources:
         requests:


### PR DESCRIPTION
Upgrade benchmarking to the latest release, which includes a networking bugfix.