### PR TITLE
Use us-west1 as a default region if the project has none.

### DIFF
--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -323,6 +323,9 @@ function configure_gke() {
                          --format "value(commonInstanceMetadata.items.key, commonInstanceMetadata.items.value)" \
                          | grep google-compute-default-region | awk '{ print $2 }')
 
+  # No default region for the project, just use hard-coded default
+  if [ -z "$default_region" ]; then default_region=us-west1; fi
+
   # use default settings or use the advanced menu
   local setup_opt_value=$(
     dialog --clear --backtitle "${BRAND}" \


### PR DESCRIPTION
`menu.sh` assumes that each project has an assigned default region. In testing with a new account, I found that this is not necessarily the case. If a project does not have a default region, then the "Advanced configuration" will hit an error during region-selection, and the menu gets tricked into thinking the user cancelled.

This PR will check if the project has a default region, and if not, uses `us-west1` as a default.