### PR TITLE
Clarify Quota increase documentation

### DIFF
--- a/docs/source/GETTING_STARTED.rst
+++ b/docs/source/GETTING_STARTED.rst
@@ -22,7 +22,7 @@ Google Cloud Setup
 
 .. note:: The recent success of deep learning has been critically dependent on accelerated hardware like GPUs. Similarly, the strength of the DeepCell Kiosk is its ability to recruit and scale GPU nodes based on demand. Google does not include these GPU nodes by default as part of its free tier thus necessitating the upgrade. For more information, please refer to `Google's blog post on the subject <https://cloud.google.com/blog/products/gcp/gpus-service-kubernetes-engine-are-now-generally-available>`_
 
-4. Apply for a `quota of at least 1 GPU <https://cloud.google.com/compute/quotas#gpus>`_ and at least `16 *In-use IP addresses* <https://cloud.google.com/compute/quotas#ip_addresses>`_ for the *Compute Engine API* of your region (by default ``us-west1``). This may take some time, as Google will need to approve each of these requests.
+4. Apply for a `quota of at least 1 GPU <https://cloud.google.com/compute/quotas#gpus>`_ and at least `16 In-use IP addresses global <https://cloud.google.com/compute/quotas#ip_addresses>`_ for the *Compute Engine API* of your region (by default ``us-west1``). This may take some time, as Google will need to approve each of these requests.
 
 .. note:: Google offers a number of GPU types. The DeepCell Kiosk uses `NVIDIA T4` GPUs for inference by default.
 

--- a/docs/source/GETTING_STARTED.rst
+++ b/docs/source/GETTING_STARTED.rst
@@ -22,7 +22,7 @@ Google Cloud Setup
 
 .. note:: The recent success of deep learning has been critically dependent on accelerated hardware like GPUs. Similarly, the strength of the DeepCell Kiosk is its ability to recruit and scale GPU nodes based on demand. Google does not include these GPU nodes by default as part of its free tier thus necessitating the upgrade. For more information, please refer to `Google's blog post on the subject <https://cloud.google.com/blog/products/gcp/gpus-service-kubernetes-engine-are-now-generally-available>`_
 
-4. Apply for a `quota of at least 1 GPU (all regions) <https://cloud.google.com/compute/quotas#gpus>`_ and at least `16 In-use IP addresses global <https://cloud.google.com/compute/quotas#ip_addresses>`_. This may take some time, as Google will need to approve each of these requests.
+4. Apply for a `quota of at least 1 "GPU (all regions)" <https://cloud.google.com/compute/quotas#gpus>`_ and at least `16 "In-use IP addresses global" <https://cloud.google.com/compute/quotas#ip_addresses>`_. This may take some time, as Google will need to approve each of these requests.
 
 .. note:: Google offers a number of GPU types. The DeepCell Kiosk uses `NVIDIA T4` GPUs for inference by default.
 

--- a/docs/source/GETTING_STARTED.rst
+++ b/docs/source/GETTING_STARTED.rst
@@ -22,7 +22,7 @@ Google Cloud Setup
 
 .. note:: The recent success of deep learning has been critically dependent on accelerated hardware like GPUs. Similarly, the strength of the DeepCell Kiosk is its ability to recruit and scale GPU nodes based on demand. Google does not include these GPU nodes by default as part of its free tier thus necessitating the upgrade. For more information, please refer to `Google's blog post on the subject <https://cloud.google.com/blog/products/gcp/gpus-service-kubernetes-engine-are-now-generally-available>`_
 
-4. Apply for a `quota of at least 1 GPU <https://cloud.google.com/compute/quotas#gpus>`_ and at least `16 In-use IP addresses global <https://cloud.google.com/compute/quotas#ip_addresses>`_ for the *Compute Engine API* of your region (by default ``us-west1``). This may take some time, as Google will need to approve each of these requests.
+4. Apply for a `quota of at least 1 GPU (all regions) <https://cloud.google.com/compute/quotas#gpus>`_ and at least `16 In-use IP addresses global <https://cloud.google.com/compute/quotas#ip_addresses>`_ for the *Compute Engine API* of your region (by default ``us-west1``). This may take some time, as Google will need to approve each of these requests.
 
 .. note:: Google offers a number of GPU types. The DeepCell Kiosk uses `NVIDIA T4` GPUs for inference by default.
 

--- a/docs/source/GETTING_STARTED.rst
+++ b/docs/source/GETTING_STARTED.rst
@@ -22,7 +22,7 @@ Google Cloud Setup
 
 .. note:: The recent success of deep learning has been critically dependent on accelerated hardware like GPUs. Similarly, the strength of the DeepCell Kiosk is its ability to recruit and scale GPU nodes based on demand. Google does not include these GPU nodes by default as part of its free tier thus necessitating the upgrade. For more information, please refer to `Google's blog post on the subject <https://cloud.google.com/blog/products/gcp/gpus-service-kubernetes-engine-are-now-generally-available>`_
 
-4. Apply for a `quota of at least 1 GPU (all regions) <https://cloud.google.com/compute/quotas#gpus>`_ and at least `16 In-use IP addresses global <https://cloud.google.com/compute/quotas#ip_addresses>`_ for the *Compute Engine API* of your region (by default ``us-west1``). This may take some time, as Google will need to approve each of these requests.
+4. Apply for a `quota of at least 1 GPU (all regions) <https://cloud.google.com/compute/quotas#gpus>`_ and at least `16 In-use IP addresses global <https://cloud.google.com/compute/quotas#ip_addresses>`_. This may take some time, as Google will need to approve each of these requests.
 
 .. note:: Google offers a number of GPU types. The DeepCell Kiosk uses `NVIDIA T4` GPUs for inference by default.
 

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -449,7 +449,7 @@ function configure_gke() {
   local min_addresses=16
   local in_use_addresses=$(echo "${all_quotas}" | grep IN_USE_ADDRESSES | awk '{print int($2)}')
   if [ $in_use_addresses -lt $min_addresses ]; then
-    error_text=("\nThe cluster requires at least ${min_addresses} In-use IP Addresses."
+    error_text=("\nThe cluster requires at least ${min_addresses} In-use IP addresses global."
                 "\n\nPlease request a quota increase from the Google Cloud console.")
     msgbox "Warning!" "${error_text[*]}"
     return 0

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -454,7 +454,15 @@ function configure_gke() {
     msgbox "Warning!" "${error_text[*]}"
     return 0
   fi
-  # TODO: Should have a quota of at leat 1 GPU of the requested type.
+  # Should have a quota of at least 1 for global GPUs.
+  local min_gpus=1
+  local gpus_all_regions=$(echo "${all_quotas}" | grep GPUS_ALL_REGIONS | awk '{print int($2)}')
+  if [ $gpus_all_regions -lt $min_gpus ]; then
+    error_text=("\nThe cluster requires at least ${min_gpus} GPU (all regions)."
+                "\n\nPlease request a quota increase from the Google Cloud console.")
+    msgbox "Warning!" "${error_text[*]}"
+    return 0
+  fi
 
   # Find at least 2 zones to deploy the cluster.
   # If GPUs are not available in at least 2 zones, the user must restart.


### PR DESCRIPTION
Going through the Getting Started docs with a brand new user account, I accidentally set up the quota for a region. We check the Global quota, and therefore I could not set up a cluster, even though I had followed instructions.

This PR clarifies the instructions by including the quota name exactly as it appears in the cloud console.

---

Edit: Also clarifying the GPU quota, as the user must request at least one `GPU (all regions)`. I was confused, since I already have a quota for 1 T4 gpu, but the aforementioned quota must also be increased.