### PR TITLE
Bugfix for GPU quota check.

### DIFF
--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -460,7 +460,7 @@ function configure_gke() {
   # Should have a quota of at least 1 for global GPUs.
   local min_gpus=1
   local gpus_all_regions=$(echo "${all_quotas}" | grep GPUS_ALL_REGIONS | awk '{print int($2)}')
-  if [ $gpus_all_regions -lt $min_gpus ]; then
+  if [ ${gpus_all_regions:-$min_gpus} -lt $min_gpus ]; then
     error_text=("\nThe cluster requires at least ${min_gpus} GPU (all regions)."
                 "\n\nPlease request a quota increase from the Google Cloud console.")
     msgbox "Warning!" "${error_text[*]}"


### PR DESCRIPTION
GPU_ALL_REGIONS may not always exist in a quota check. If it does not exist, just assume the user has the quota available and set the default value to the minimum.