### PR TITLE
Automatically delete prometheus CRDs when the chart is deleted.

### DIFF
--- a/conf/helmfile.d/0600.prometheus-operator.yaml
+++ b/conf/helmfile.d/0600.prometheus-operator.yaml
@@ -116,6 +116,11 @@ releases:
                 deployment: tracking-consumer
                 namespace: deepcell
 
+      ## Manages Prometheus and Alertmanager components
+      ##
+      prometheusOperator:
+        cleanupCustomResource: true
+
       ## Using default values from https://github.com/helm/charts/blob/master/stable/grafana/values.yaml
       ##
       grafana:


### PR DESCRIPTION
By setting `prometheusOperator.cleanupCustomResource` to `true`, the chart removes the Custom Resource Definition on chart deletion.