### PR TITLE
Add links for client & ImageJ Plugin to architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,15 +62,17 @@ Check out our [docs](https://deepcell-kiosk.readthedocs.io/en/master/GETTING_STA
 
 - [Frontend](https://github.com/vanvalenlab/kiosk-frontend): API for creating and managing jobs, and a React-based web interface for the DeepCell Kiosk.
 
-  - [ImageJ Plugin](https://github.com/vanvalenlab/kiosk-imageJ-plugin): An ImageJ 1.x plugin for processing images with an existing cluster.
-
-  - [Command-line Interface](https://github.com/vanvalenlab/kiosk-client): A python-based CLI for submitting and managing DeepCell Kiosk jobs.
-
 - [Consumer](https://github.com/vanvalenlab/kiosk-redis-consumer): Retrieves items from the Job Queue and handles the processing pipeline for that item. Each consumer only works on one item at a time.
 
 - [Model Server](https://github.com/vanvalenlab/kiosk-tf-serving): Serves models over a gRPC API, allowing consumers to send data and get back predictions.
 
 - [GPU Autoscaler](https://github.com/vanvalenlab/kiosk-autoscaler): Automatically and efficiently scales Kubernetes GPU resources.
+
+- _Kiosk Interfaces_:
+
+  - [ImageJ Plugin](https://github.com/vanvalenlab/kiosk-imageJ-plugin): An ImageJ 1.x plugin for processing images with an existing cluster.
+
+  - [Command-line Interface](https://github.com/vanvalenlab/kiosk-client): A python-based CLI for submitting and managing DeepCell Kiosk jobs.
 
 - _Not pictured above_:
 

--- a/README.md
+++ b/README.md
@@ -62,15 +62,15 @@ Check out our [docs](https://deepcell-kiosk.readthedocs.io/en/master/GETTING_STA
 
 - [Frontend](https://github.com/vanvalenlab/kiosk-frontend): API for creating and managing jobs, and a React-based web interface for the DeepCell Kiosk.
 
+  - [ImageJ Plugin](https://github.com/vanvalenlab/kiosk-imageJ-plugin): An ImageJ 1.x plugin for processing images with an existing DeepCell Kiosk cluster.
+
+  - [Command-line Interface](https://github.com/vanvalenlab/kiosk-client): A python-based CLI for submitting and managing DeepCell Kiosk jobs.
+
 - [Consumer](https://github.com/vanvalenlab/kiosk-redis-consumer): Retrieves items from the Job Queue and handles the processing pipeline for that item. Each consumer only works on one item at a time.
 
 - [Model Server](https://github.com/vanvalenlab/kiosk-tf-serving): Serves models over a gRPC API, allowing consumers to send data and get back predictions.
 
 - [GPU Autoscaler](https://github.com/vanvalenlab/kiosk-autoscaler): Automatically and efficiently scales Kubernetes GPU resources.
-
-- [ImageJ Plugin](https://github.com/vanvalenlab/kiosk-imageJ-plugin): An ImageJ 1.x plugin for processing images with an existing DeepCell Kiosk cluster.
-
-- [Command-line Interface](https://github.com/vanvalenlab/kiosk-client): A python-based CLI for submitting and managing DeepCell Kiosk jobs.
 
 - _Not pictured above_:
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Check out our [docs](https://deepcell-kiosk.readthedocs.io/en/master/GETTING_STA
 
 - [Frontend](https://github.com/vanvalenlab/kiosk-frontend): API for creating and managing jobs, and a React-based web interface for the DeepCell Kiosk.
 
-  - [ImageJ Plugin](https://github.com/vanvalenlab/kiosk-imageJ-plugin): An ImageJ 1.x plugin for processing images with an existing DeepCell Kiosk cluster.
+  - [ImageJ Plugin](https://github.com/vanvalenlab/kiosk-imageJ-plugin): An ImageJ 1.x plugin for processing images with an existing cluster.
 
   - [Command-line Interface](https://github.com/vanvalenlab/kiosk-client): A python-based CLI for submitting and managing DeepCell Kiosk jobs.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Tracked Image
 Start a terminal shell and install the DeepCell Kiosk wrapper script:
 
 ```bash
-docker run -e DOCKER_TAG=1.2.1 vanvalenlab/kiosk-console:1.2.1 | sudo bash
+docker run -e DOCKER_TAG=1.3.0 vanvalenlab/kiosk-console:1.3.0 | sudo bash
 ```
 
 To start the kiosk, just run `kiosk-console` from the terminal shell.

--- a/README.md
+++ b/README.md
@@ -60,15 +60,15 @@ Check out our [docs](https://deepcell-kiosk.readthedocs.io/en/master/GETTING_STA
 
 ![Kiosk Architecture](https://raw.githubusercontent.com/vanvalenlab/kiosk-console/master/docs/images/Kiosk_Architecture.png)
 
-- [Frontend](https://github.com/vanvalenlab/kiosk-frontend): API for creating and managing jobs, and a React-based web interface for the DeepCell Kiosk.
-
 - [Consumer](https://github.com/vanvalenlab/kiosk-redis-consumer): Retrieves items from the Job Queue and handles the processing pipeline for that item. Each consumer only works on one item at a time.
 
 - [Model Server](https://github.com/vanvalenlab/kiosk-tf-serving): Serves models over a gRPC API, allowing consumers to send data and get back predictions.
 
 - [GPU Autoscaler](https://github.com/vanvalenlab/kiosk-autoscaler): Automatically and efficiently scales Kubernetes GPU resources.
 
-- _Kiosk Interfaces_:
+- [Frontend](https://github.com/vanvalenlab/kiosk-frontend): API for creating and managing jobs, and a React-based web interface for the DeepCell Kiosk.
+
+- _Additional Data Entry Tools_:
 
   - [ImageJ Plugin](https://github.com/vanvalenlab/kiosk-imageJ-plugin): An ImageJ 1.x plugin for processing images with an existing cluster.
 

--- a/README.md
+++ b/README.md
@@ -68,12 +68,15 @@ Check out our [docs](https://deepcell-kiosk.readthedocs.io/en/master/GETTING_STA
 
 - [GPU Autoscaler](https://github.com/vanvalenlab/kiosk-autoscaler): Automatically and efficiently scales Kubernetes GPU resources.
 
+- [ImageJ Plugin](https://github.com/vanvalenlab/kiosk-imageJ-plugin): An ImageJ 1.x plugin for processing images with an existing DeepCell Kiosk cluster.
+
+- [Command-line Interface](https://github.com/vanvalenlab/kiosk-client): A python-based CLI for submitting and managing DeepCell Kiosk jobs.
+
 - _Not pictured above_:
 
-  * [Bucket Monitor](https://github.com/vanvalenlab/kiosk-bucket-monitor): Purges the bucket of uploaded and processed files that are older than `AGE_THRESHOLD`, 3 days by default.
+  - [Bucket Monitor](https://github.com/vanvalenlab/kiosk-bucket-monitor): Purges the bucket of uploaded and processed files that are older than `AGE_THRESHOLD`, 3 days by default.
 
-  * [Janitor](https://github.com/vanvalenlab/kiosk-redis-janitor): Monitors in-progress items and makes sure no jobs get left un-finished.
-
+  - [Janitor](https://github.com/vanvalenlab/kiosk-redis-janitor): Monitors in-progress items and makes sure no jobs get left un-finished.
 
 ## Contribute
 

--- a/docs/source/GETTING_STARTED.rst
+++ b/docs/source/GETTING_STARTED.rst
@@ -113,7 +113,7 @@ You are now ready to start the Kiosk!
 
 .. code-block:: bash
 
-    docker run -e DOCKER_TAG=1.2.1 vanvalenlab/kiosk-console:1.2.1 | sudo bash
+    docker run -e DOCKER_TAG=1.3.0 vanvalenlab/kiosk-console:1.3.0 | sudo bash
 
 .. note:: This command and the one that follows may need to be preceded by `sudo` depending on your permission settings. This will require you to enter your password.
 


### PR DESCRIPTION
While the ImageJ and CLI were added to the diagram we did not add the description and link to the bottom. This PR amends that and also bumps the version to 1.3.0 for the pending release.