### PR TITLE
Fix frontend ingress issue when no hosts are provided.

### DIFF
--- a/conf/charts/frontend/templates/ingress.yaml
+++ b/conf/charts/frontend/templates/ingress.yaml
@@ -18,6 +18,12 @@ metadata:
 {{- end }}
 spec:
   rules:
+    - http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
   {{- range .Values.ingress.hosts }}
     - host: {{ . }}
       http:

--- a/conf/charts/frontend/values.yaml
+++ b/conf/charts/frontend/values.yaml
@@ -17,11 +17,11 @@ ingress:
     #nginx.ingress.kubernetes.io/rewrite-target: /
     #nginx.ingress.kubernetes.io/ssl-redirect: "false"
     #nginx.ingress.kubernetes.io/proxy-body-size: "25m"
-  hosts:
-    - deepcell.example.com
+  hosts: []
+  # - example.com
   tls: []
   #  - hosts:
-  #      - deepcell.example.com
+  #      - example.com
   #    secretName: tls-cert
 
 service:

--- a/conf/helmfile.d/0300.frontend.yaml
+++ b/conf/helmfile.d/0300.frontend.yaml
@@ -60,8 +60,7 @@ releases:
           nginx.ingress.kubernetes.io/proxy-body-size: "1g"
           nginx.ingress.kubernetes.io/auth-tls-secret: "deepcell/tls-cert"
           cert-manager.io/cluster-issuer: "letsencrypt-staging"
-        hosts:
-          - deepcell.example.com
+        hosts: []
           # - deepcell.org
           # - www.deepcell.org
         tls: []


### PR DESCRIPTION
There should be a default rule for HTTP traffic if there are no hosts available.

Default `hosts` values have also been updated to empty lists as opposed to `example.com`.