### PR TITLE
Create tf-serving configuration files using an initContainer.

### DIFF
--- a/conf/charts/tf-serving/Chart.yaml
+++ b/conf/charts/tf-serving/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: tf-serving
-version: 0.1.0
+version: 0.2.0
 #kubeVersion: ^1.9.8
 description: This helm chart provides the Tensorflow-serving backend functionality of the Deepcell application.
 keywords:

--- a/conf/charts/tf-serving/templates/deployment.yaml
+++ b/conf/charts/tf-serving/templates/deployment.yaml
@@ -36,15 +36,15 @@ spec:
     {{- end }}
       dnsPolicy: Default
       volumes:
-      - name: configdir
+      - name: {{ .Values.configWriter.mountedVolume.name }}
         emptyDir: {}
       # These containers are run during pod initialization
       initContainers:
       - name: install
         image: "{{ .Values.configWriter.image.repository }}:{{ .Values.configWriter.image.tag }}"
         volumeMounts:
-        - name: configdir
-          mountPath: "/config"
+        - name: {{ .Values.configWriter.mountedVolume.name }}
+          mountPath: {{ .Values.configWriter.mountedVolume.path }}
         env:
 {{- range $name, $value := .Values.env }}
 {{- if not ( empty $value) }}
@@ -67,8 +67,8 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
-          - name: configdir
-            mountPath: "/config"
+          - name: {{ .Values.configWriter.mountedVolume.name }}
+            mountPath: {{ .Values.configWriter.mountedVolume.path }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         ports:

--- a/conf/charts/tf-serving/templates/deployment.yaml
+++ b/conf/charts/tf-serving/templates/deployment.yaml
@@ -52,6 +52,16 @@ spec:
           value: {{ $value | quote }}
 {{- end }}
 {{- end }}
+{{ $dot := . }}
+{{- range $name, $value := .Values.secrets }}
+{{- if not ( empty $value) }}
+        - name: {{ $name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "secretName" $dot }}
+              key: {{ $name }}
+{{- end }}
+{{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/conf/charts/tf-serving/templates/deployment.yaml
+++ b/conf/charts/tf-serving/templates/deployment.yaml
@@ -34,10 +34,31 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+      dnsPolicy: Default
+      volumes:
+      - name: configdir
+        emptyDir: {}
+      # These containers are run during pod initialization
+      initContainers:
+      - name: install
+        image: "{{ .Values.configWriter.image.repository }}:{{ .Values.configWriter.image.tag }}"
+        volumeMounts:
+        - name: configdir
+          mountPath: "/config"
+        env:
+{{- range $name, $value := .Values.env }}
+{{- if not ( empty $value) }}
+        - name: {{ $name }}
+          value: {{ $value | quote }}
+{{- end }}
+{{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        volumeMounts:
+          - name: configdir
+            mountPath: "/config"
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         ports:

--- a/conf/charts/tf-serving/templates/deployment.yaml
+++ b/conf/charts/tf-serving/templates/deployment.yaml
@@ -42,6 +42,7 @@ spec:
       initContainers:
       - name: install
         image: "{{ .Values.configWriter.image.repository }}:{{ .Values.configWriter.image.tag }}"
+        imagePullPolicy: {{ .Values.configWriter.image.pullPolicy }}
         volumeMounts:
         - name: {{ .Values.configWriter.mountedVolume.name }}
           mountPath: {{ .Values.configWriter.mountedVolume.path }}

--- a/conf/charts/tf-serving/values.yaml
+++ b/conf/charts/tf-serving/values.yaml
@@ -10,6 +10,10 @@ image:
   pullPolicy: IfNotPresent
 
 configWriter:
+  mountedVolume:
+    name: configdir
+    path: /config
+
   image:
     repository: vanvalenlab/kiosk-tf-serving-config-writer
     tag: latest
@@ -55,8 +59,8 @@ env:
   PORT: 8500
   REST_API_PORT: 8501
   REST_API_TIMEOUT: 30000
-  MODEL_CONFIG_FILE: /kiosk/tf-serving/models.conf
-  BATCHING_CONFIG_FILE: /kiosk/tf-serving/batching_config.txt
+  MODEL_CONFIG_FILE: /config/models.conf
+  BATCHING_CONFIG_FILE: /config/batching_config.txt
   ENABLE_BATCHING: "true"
   MAX_BATCH_SIZE: 1
   BATCH_TIMEOUT_MICROS: 0
@@ -66,7 +70,7 @@ env:
   CLOUD_PROVIDER: '{{ env "CLOUD_PROVIDER" | default "aws" }}'
   TF_CPP_MIN_LOG_LEVEL: 0
   TF_SESSION_PARALLELISM: 0
-  MONITORING_CONFIG_FILE: /kiosk/tf-serving/monitoring_config.txt
+  MONITORING_CONFIG_FILE: /config/monitoring_config.txt
   PROMETHEUS_MONITORING_ENABLED: "true"
   PROMETHEUS_MONITORING_PATH: /monitoring/prometheus/metrics
 

--- a/conf/charts/tf-serving/values.yaml
+++ b/conf/charts/tf-serving/values.yaml
@@ -9,6 +9,12 @@ image:
   tag: latest
   pullPolicy: IfNotPresent
 
+configWriter:
+  image:
+    repository: vanvalenlab/kiosk-tf-serving-config-writer
+    tag: latest
+    pullPolicy: IfNotPresent
+
 service:
   type: ClusterIP
 

--- a/conf/helmfile.d/0310.tf-serving.yaml
+++ b/conf/helmfile.d/0310.tf-serving.yaml
@@ -22,7 +22,7 @@ releases:
     vendor: vanvalenlab
     default: true
   chart: '{{ env "CHARTS_PATH" | default "/conf/charts" }}/tf-serving'
-  version: 0.1.0
+  version: 0.2.0
   values:
     - replicas: 0
 

--- a/conf/helmfile.d/0310.tf-serving.yaml
+++ b/conf/helmfile.d/0310.tf-serving.yaml
@@ -31,6 +31,10 @@ releases:
         tag: separated
       
       configWriter:
+        mountedVolume:
+          name: configdir
+          path: /config
+
         image:
           repository: vanvalenlab/kiosk-tf-serving-config-writer
           tag: dev
@@ -90,8 +94,8 @@ releases:
         PORT: 8500
         REST_API_PORT: 8501
         REST_API_TIMEOUT: 30000
-        MODEL_CONFIG_FILE: /kiosk/tf-serving/models.conf
-        BATCHING_CONFIG_FILE: /kiosk/tf-serving/batching_config.txt
+        MODEL_CONFIG_FILE: /config/models.conf
+        BATCHING_CONFIG_FILE: /config/batching_config.txt
         ENABLE_BATCHING: "true"
         MAX_BATCH_SIZE: 128
         BATCH_TIMEOUT_MICROS: 0
@@ -101,7 +105,7 @@ releases:
         CLOUD_PROVIDER: '{{ env "CLOUD_PROVIDER" | default "aws" }}'
         TF_CPP_MIN_LOG_LEVEL: 0
         TF_SESSION_PARALLELISM: 0
-        MONITORING_CONFIG_FILE: /kiosk/tf-serving/monitoring_config.txt
+        MONITORING_CONFIG_FILE: /config/monitoring_config.txt
         PROMETHEUS_MONITORING_ENABLED: "true"
         PROMETHEUS_MONITORING_PATH: /monitoring/prometheus/metrics
 

--- a/conf/helmfile.d/0310.tf-serving.yaml
+++ b/conf/helmfile.d/0310.tf-serving.yaml
@@ -28,7 +28,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-tf-serving
-        tag: separated
+        tag: 0.3.0
       
       configWriter:
         mountedVolume:
@@ -37,7 +37,7 @@ releases:
 
         image:
           repository: vanvalenlab/kiosk-tf-serving-config-writer
-          tag: dev
+          tag: 0.3.0
           pullPolicy: IfNotPresent
 
       resources:

--- a/conf/helmfile.d/0310.tf-serving.yaml
+++ b/conf/helmfile.d/0310.tf-serving.yaml
@@ -28,7 +28,13 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-tf-serving
-        tag: 0.2.1
+        tag: separated
+      
+      configWriter:
+        image:
+          repository: vanvalenlab/kiosk-tf-serving-config-writer
+          tag: dev
+          pullPolicy: IfNotPresent
 
       resources:
         requests:


### PR DESCRIPTION
By separating the Pod into 2 containers (config writer and model server) we can significantly reduce the image sizes.

Closes #361 
