### PR TITLE
Template frontend ingress annotations using CERTIFICATE_MANAGER_ENABLED

### DIFF
--- a/conf/helmfile.d/0300.frontend.yaml
+++ b/conf/helmfile.d/0300.frontend.yaml
@@ -58,11 +58,11 @@ releases:
           kubernetes.io/ingress.class: "nginx"
           nginx.ingress.kubernetes.io/ssl-redirect: "false"
           nginx.ingress.kubernetes.io/proxy-body-size: "1g"
-{{ if ne (env "CERTIFICATE_MANAGER_ENABLED" | default "") "" }}
+          {{ if ne (env "CERTIFICATE_MANAGER_ENABLED" | default "") "" }}
           nginx.ingress.kubernetes.io/auth-tls-secret: "deepcell/tls-cert"
           # Update to "letsencrypt-prod" for production.
           cert-manager.io/cluster-issuer: "letsencrypt-staging"
-{{ end }}
+          {{ end }}
 
         # Use $DNS_DOMAIN_NAME in production
         hosts: []

--- a/conf/helmfile.d/0300.frontend.yaml
+++ b/conf/helmfile.d/0300.frontend.yaml
@@ -65,14 +65,16 @@ releases:
           {{ end }}
 
         # Use $DNS_DOMAIN_NAME in production
-        hosts: []
-          # - deepcell.org
-          # - www.deepcell.org
-        tls: []
-          # - hosts:
-          #   - deepcell.org
-          #   - www.deepcell.org
-          #   secretName: tls-cert
+        {{ if ne (env "CERTIFICATE_MANAGER_ENABLED" | default "") "" }}
+        hosts:
+          - {{ env "DNS_DOMAIN_NAME" | default "deepcell.org" }}
+          - www.{{ env "DNS_DOMAIN_NAME" | default "deepcell.org" }}
+        tls:
+          - hosts:
+            - {{ env "DNS_DOMAIN_NAME" | default "deepcell.org" }}
+            - www.{{ env "DNS_DOMAIN_NAME" | default "deepcell.org" }}
+            secretName: tls-cert
+        {{ end }}
 
       env:
         PORT: 8080

--- a/conf/helmfile.d/0300.frontend.yaml
+++ b/conf/helmfile.d/0300.frontend.yaml
@@ -58,8 +58,13 @@ releases:
           kubernetes.io/ingress.class: "nginx"
           nginx.ingress.kubernetes.io/ssl-redirect: "false"
           nginx.ingress.kubernetes.io/proxy-body-size: "1g"
+{{ if ne (env "CERTIFICATE_MANAGER_ENABLED" | default "") "" }}
           nginx.ingress.kubernetes.io/auth-tls-secret: "deepcell/tls-cert"
+          # Update to "letsencrypt-prod" for production.
           cert-manager.io/cluster-issuer: "letsencrypt-staging"
+{{ end }}
+
+        # Use $DNS_DOMAIN_NAME in production
         hosts: []
           # - deepcell.org
           # - www.deepcell.org


### PR DESCRIPTION
Only include the certificate-manager annotations if the `CERTIFICATE_MANAGER_ENABLED` is configured.