### PR TITLE
Fix whitespace issue in tasks/Makefile.kubectl

### DIFF
--- a/conf/Makefile
+++ b/conf/Makefile
@@ -50,6 +50,7 @@ test/destroy: \
 
 ## Target for testing cluster deployment
 test/integration/gke/deploy: export CLOUDSDK_CONTAINER_CLUSTER = deepcell-test-$(shell bash -c 'echo $$((1 + $$RANDOM % 1000))')
+test/integration/gke/deploy: export CERTIFICATE_MANAGER_ENABLED = true
 test/integration/gke/deploy:
 	make test/create
 	# TODO: add more testing workflows

--- a/conf/tasks/Makefile.kubectl
+++ b/conf/tasks/Makefile.kubectl
@@ -51,7 +51,7 @@ kubectl/destroy/prometheus/operator:
 
 kubectl/create/certificates:
 ifneq "" "${CERTIFICATE_MANAGER_ENABLED}"
-  -@gomplate -f addons/certificate-issuers.yaml | kubectl apply -f -
+	-@gomplate -f addons/certificate-issuers.yaml | kubectl apply -f -
 endif
 
 ## Create horizontal pod autoscalers for all relevant deployments


### PR DESCRIPTION
Whitespace in `tasks/Makefile.kubectl` cause the make commands to fail. The indentation is using spaces instead of tabs, which breaks. This PR changes the spaces to tabs and resolves the issue.

This PR also adds `CERTIFICATE_MANAGER_ENABLED="true"` so that the certificate make commands are tested in unit tests.