### PR TITLE
Install procps in Redis init-sysctl container.

### DIFF
--- a/conf/helmfile.d/0100.redis.yaml
+++ b/conf/helmfile.d/0100.redis.yaml
@@ -54,6 +54,6 @@ releases:
             - /bin/sh
             - -c
             - |-
-              install_packages systemd
+              install_packages systemd procps
               sysctl -w net.core.somaxconn=10000
               echo never > /host-sys/kernel/mm/transparent_hugepage/enabled


### PR DESCRIPTION
`procps` is required to run `sysctl` in the init-sysctl container of the Redis helm chart.