### PR TITLE
Move the frontend HPA definition into the helm chart.

### DIFF
--- a/conf/addons/hpa.yaml
+++ b/conf/addons/hpa.yaml
@@ -25,24 +25,6 @@ spec:
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: frontend
-  namespace: deepcell
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: frontend
-  minReplicas: 1
-  maxReplicas: {{ mul $max_gpus 10 }}
-  metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      targetAverageUtilization: 80
----
-apiVersion: autoscaling/v2beta1
-kind: HorizontalPodAutoscaler
-metadata:
   name: segmentation-consumer
   namespace: deepcell
 spec:

--- a/conf/charts/frontend/Chart.yaml
+++ b/conf/charts/frontend/Chart.yaml
@@ -13,6 +13,6 @@ maintainers:
     email: bbannon@caltech.edu
     url: vanvalen.caltech.edu
 engine: gotpl
-appVersion: 0.1.0
+appVersion: 0.6.0
 deprecated: false
 tillerVersion: ^2.9.1

--- a/conf/charts/frontend/Chart.yaml
+++ b/conf/charts/frontend/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: frontend
-version: 0.1.0
+version: 0.2.0
 #kubeVersion: ^1.9.8
 description: This project provides the frontend interface for the Tensorflow-serving backend of Deepcell.
 keywords:

--- a/conf/charts/frontend/templates/hpa.yaml
+++ b/conf/charts/frontend/templates/hpa.yaml
@@ -15,7 +15,7 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ template "coredns.fullname" . }}
+    name: {{ template "fullname" . }}
   minReplicas: {{ .Values.hpa.minReplicas }}
   maxReplicas: {{ .Values.hpa.maxReplicas }}
   metrics:

--- a/conf/charts/frontend/templates/hpa.yaml
+++ b/conf/charts/frontend/templates/hpa.yaml
@@ -1,0 +1,23 @@
+{{- if (.Values.hpa.enabled) }}
+---
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "coredns.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+{{ toYaml .Values.hpa.metrics | indent 4 }}
+{{- end }}

--- a/conf/charts/frontend/templates/ingress.yaml
+++ b/conf/charts/frontend/templates/ingress.yaml
@@ -1,36 +1,33 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "fullname" . -}}
-{{- $ingressPath := .Values.ingress.path -}}
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  name: {{ $fullName }}
+  name: {{ template "fullname" . }}
   labels:
     app: {{ template "name" . }}
     chart: {{ template "chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-{{- range $name, $value := .Values.ingress.annotations }}
-{{- if not ( empty $value) }}
-    {{ $name }}: {{ $value | quote }}
-{{- end }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
 {{- end }}
 spec:
   rules:
     - http:
         paths:
-          - path: {{ $ingressPath }}
+          - path: {{ .Values.ingress.path }}
             backend:
-              serviceName: {{ $fullName }}
+              serviceName: {{ template "fullname" . }}
               servicePort: http
   {{- range .Values.ingress.hosts }}
     - host: {{ . }}
       http:
         paths:
-          - path: {{ $ingressPath }}
+          - path: {{ template "fullname" . }}
             backend:
-              serviceName: {{ $fullName }}
+              serviceName: {{ template "fullname" . }}
               servicePort: http
   {{- end }}
   {{- if .Values.ingress.tls }}

--- a/conf/charts/frontend/templates/service.yaml
+++ b/conf/charts/frontend/templates/service.yaml
@@ -3,7 +3,10 @@ apiVersion: v1
 metadata:
   name: {{ template "fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 {{- if .Values.service.annotations }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}

--- a/conf/charts/frontend/values.yaml
+++ b/conf/charts/frontend/values.yaml
@@ -52,11 +52,9 @@ env:
   REDIS_PORT: "6379"
   MODEL_PREFIX: "models/"
   AWS_REGION: "us-east-1"
-  CLOUD_PROVIDER: "aws"
 
 secrets:
-  AWS_ACCESS_KEY_ID: "change_me"
-  AWS_SECRET_ACCESS_KEY: "change_me"
-  AWS_S3_BUCKET: "change_me"
-  GCLOUD_STORAGE_BUCKET: "change_me"
-  GCLOUD_PROJECT_ID: "change_me"
+  AWS_ACCESS_KEY_ID: ""
+  AWS_SECRET_ACCESS_KEY: ""
+  GCLOUD_PROJECT_ID: ""
+  STORAGE_BUCKET: "s3://example-bucket"

--- a/conf/charts/frontend/values.yaml
+++ b/conf/charts/frontend/values.yaml
@@ -37,6 +37,12 @@ service:
   httpsTargetPort: 8443
   externalHttpsPort: 8443
 
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 2
+  metrics: {}
+
 resources: {}
 
 env:

--- a/conf/charts/frontend/values.yaml
+++ b/conf/charts/frontend/values.yaml
@@ -6,7 +6,7 @@ replicas: 1
 
 image:
   repository: vanvalenlab/kiosk-frontend
-  tag: latest
+  tag: 0.6.0
   pullPolicy: IfNotPresent
 
 ingress:

--- a/conf/helmfile.d/0300.frontend.yaml
+++ b/conf/helmfile.d/0300.frontend.yaml
@@ -79,7 +79,7 @@ releases:
       hpa:
         enabled: true
         minReplicas: 1
-        maxReplicas: 10
+        maxReplicas: {{ mul (int (env "GPU_NODE_MAX_SIZE" | default 1)) 10 }}
         metrics:
         - type: Resource
           resource:

--- a/conf/helmfile.d/0300.frontend.yaml
+++ b/conf/helmfile.d/0300.frontend.yaml
@@ -28,7 +28,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-frontend
-        tag: 0.5.0
+        tag: 0.6.0
 
       resources:
         requests:
@@ -93,13 +93,15 @@ releases:
         REDIS_SENTINEL: "true"
         MODEL_PREFIX: "models/"
         AWS_REGION: '{{ env "AWS_REGION" | default "us-east-1" }}'
-        CLOUD_PROVIDER: '{{ env "CLOUD_PROVIDER" | default "aws" }}'
         UPLOAD_PREFIX: "uploads/"
         JOB_TYPES: "segmentation,tracking"
 
       secrets:
         AWS_ACCESS_KEY_ID: '{{ env "AWS_ACCESS_KEY_ID" | default "NA" }}'
         AWS_SECRET_ACCESS_KEY: '{{ env "AWS_SECRET_ACCESS_KEY" | default "NA" }}'
-        AWS_S3_BUCKET: '{{ env "AWS_S3_BUCKET" | default "NA" }}'
-        GCLOUD_STORAGE_BUCKET: '{{ env "CLOUDSDK_BUCKET" | default "NA" }}'
         GCLOUD_PROJECT_ID: '{{ env "PROJECT" | default "NA" }}'
+{{ if eq (env "CLOUD_PROVIDER" | default "aws") "aws" }}
+        STORAGE_BUCKET: 's3://{{ env "AWS_S3_BUCKET" | default "NA" }}'
+{{ else }}
+        STORAGE_BUCKET: 'gs://{{ env "CLOUDSDK_BUCKET" | default "NA" }}'
+{{ end }}

--- a/conf/helmfile.d/0300.frontend.yaml
+++ b/conf/helmfile.d/0300.frontend.yaml
@@ -28,7 +28,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-frontend
-        tag: 0.4.2
+        tag: 0.5.0
 
       resources:
         requests:
@@ -75,6 +75,16 @@ releases:
             - www.{{ env "DNS_DOMAIN_NAME" | default "deepcell.org" }}
             secretName: tls-cert
         {{ end }}
+
+      hpa:
+        enabled: true
+        minReplicas: 1
+        maxReplicas: 10
+        metrics:
+        - type: Resource
+          resource:
+            name: cpu
+            targetAverageUtilization: 80
 
       env:
         PORT: 8080

--- a/conf/helmfile.d/0300.frontend.yaml
+++ b/conf/helmfile.d/0300.frontend.yaml
@@ -99,7 +99,7 @@ releases:
       secrets:
         AWS_ACCESS_KEY_ID: '{{ env "AWS_ACCESS_KEY_ID" | default "NA" }}'
         AWS_SECRET_ACCESS_KEY: '{{ env "AWS_SECRET_ACCESS_KEY" | default "NA" }}'
-        GCLOUD_PROJECT_ID: '{{ env "PROJECT" | default "NA" }}'
+        GCLOUD_PROJECT_ID: '{{ env "CLOUDSDK_CORE_PROJECT" | default "NA" }}'
 {{ if eq (env "CLOUD_PROVIDER" | default "aws") "aws" }}
         STORAGE_BUCKET: 's3://{{ env "AWS_S3_BUCKET" | default "NA" }}'
 {{ else }}

--- a/conf/helmfile.d/0300.frontend.yaml
+++ b/conf/helmfile.d/0300.frontend.yaml
@@ -22,7 +22,7 @@ releases:
     vendor: vanvalenlab
     default: true
   chart: '{{ env "CHARTS_PATH" | default "/conf/charts" }}/frontend'
-  version: 0.1.0
+  version: 0.2.0
   values:
     - replicas: 1
 


### PR DESCRIPTION
* Upgrade frontend chart version to 0.2.0 and frontend application version to 0.6.0.
* Remove `CLOUD_PROVIDER`, `GCLOUD_STORAGE_BUCKET`, and `AWS_S3_BUCKET` environment variables in favor of a single `STORAGE_BUCKET` with the bucket protocol (e.g. `gs://`).
* Move the HPA definition from `addons/` into the helm chart.
* Standardize the ingress and service templates.