### PR TITLE
Move the tf-serving HPA into the helm chart.

### DIFF
--- a/conf/addons/hpa.yaml
+++ b/conf/addons/hpa.yaml
@@ -3,28 +3,6 @@
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: tf-serving
-  namespace: deepcell
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: tf-serving
-  minReplicas: 1
-  maxReplicas: {{ $max_gpus }}
-  metrics:
-  - type: Object
-    object:
-      metricName: tf_serving_gpu_usage
-      target:
-        apiVersion: v1
-        kind: Namespace
-        name: tf_serving_gpu_usage
-      targetValue: 70
----
-apiVersion: autoscaling/v2beta1
-kind: HorizontalPodAutoscaler
-metadata:
   name: frontend
   namespace: deepcell
 spec:

--- a/conf/charts/tf-serving/Chart.yaml
+++ b/conf/charts/tf-serving/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: tf-serving
-version: 0.3.0
+version: 0.4.0
 #kubeVersion: ^1.9.8
 description: This helm chart provides the Tensorflow-serving backend functionality of the Deepcell application.
 keywords:
@@ -13,7 +13,7 @@ maintainers:
     email: bbannon@caltech.edu
     url: vanvalen.caltech.edu
 engine: gotpl
-appVersion: 0.1.0
+appVersion: 0.4.0
 deprecated: false
 tillerVersion: ^2.9.1
 

--- a/conf/charts/tf-serving/Chart.yaml
+++ b/conf/charts/tf-serving/Chart.yaml
@@ -16,4 +16,3 @@ engine: gotpl
 appVersion: 0.4.0
 deprecated: false
 tillerVersion: ^2.9.1
-

--- a/conf/charts/tf-serving/templates/hpa.yaml
+++ b/conf/charts/tf-serving/templates/hpa.yaml
@@ -15,7 +15,7 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ template "coredns.fullname" . }}
+    name: {{ template "fullname" . }}
   minReplicas: {{ .Values.hpa.minReplicas }}
   maxReplicas: {{ .Values.hpa.maxReplicas }}
   metrics:

--- a/conf/charts/tf-serving/templates/hpa.yaml
+++ b/conf/charts/tf-serving/templates/hpa.yaml
@@ -1,0 +1,23 @@
+{{- if (.Values.hpa.enabled) }}
+---
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "coredns.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+{{ toYaml .Values.hpa.metrics | indent 4 }}
+{{- end }}

--- a/conf/charts/tf-serving/values.yaml
+++ b/conf/charts/tf-serving/values.yaml
@@ -6,7 +6,7 @@ replicas: 0
 
 image:
   repository: vanvalenlab/kiosk-tf-serving
-  tag: latest
+  tag: 0.4.0
   pullPolicy: IfNotPresent
 
 configWriter:
@@ -16,7 +16,7 @@ configWriter:
 
   image:
     repository: vanvalenlab/kiosk-tf-serving-config-writer
-    tag: latest
+    tag: 0.4.0
     pullPolicy: IfNotPresent
 
 service:

--- a/conf/charts/tf-serving/values.yaml
+++ b/conf/charts/tf-serving/values.yaml
@@ -55,6 +55,12 @@ tolerations: {}
 
 affinity: {}
 
+hpa:
+  enabled: false
+  minReplicas: 0
+  maxReplicas: 1
+  metrics: {}
+
 env:
   PORT: 8500
   REST_API_PORT: 8501

--- a/conf/helmfile.d/0310.tf-serving.yaml
+++ b/conf/helmfile.d/0310.tf-serving.yaml
@@ -22,7 +22,7 @@ releases:
     vendor: vanvalenlab
     default: true
   chart: '{{ env "CHARTS_PATH" | default "/conf/charts" }}/tf-serving'
-  version: 0.3.0
+  version: 0.4.0
   values:
     - replicas: 0
 
@@ -76,6 +76,20 @@ releases:
           prometheus.io/path: /monitoring/prometheus/metrics
           prometheus.io/port: "8501"
           prometheus.io/scrape: "true"
+
+      hpa:
+        enabled: true
+        minReplicas: 1
+        maxReplicas: {{ int (env "GPU_NODE_MAX_SIZE" | default 1) }}
+        metrics:
+        - type: Object
+          object:
+            metricName: tf_serving_gpu_usage
+            target:
+              apiVersion: v1
+              kind: Namespace
+              name: tf_serving_gpu_usage
+            targetValue: 70
 
       annotations:
         prometheus.io/path: /monitoring/prometheus/metrics


### PR DESCRIPTION
* Upgrade tf-serving chart version to 0.4.0.
* Move the HPA definition from addons/ into the helm chart.
* Standardize the ingress and service templates.
