### PR TITLE
Migrate stable helm chart repo to charts.helm.sh/stable.

### DIFF
--- a/conf/helmfile.d/0000.ingress.yaml
+++ b/conf/helmfile.d/0000.ingress.yaml
@@ -1,7 +1,7 @@
 repositories:
 # Stable repo of official helm charts
 - name: stable
-  url: https://kubernetes-charts.storage.googleapis.com
+  url: https://charts.helm.sh/stable
 
 releases:
 

--- a/conf/helmfile.d/0110.prometheus-redis-exporter.yaml
+++ b/conf/helmfile.d/0110.prometheus-redis-exporter.yaml
@@ -10,7 +10,7 @@ helmDefaults:
 repositories:
   # Stable repo of official helm charts
   - name: stable
-    url: https://kubernetes-charts.storage.googleapis.com
+    url: https://charts.helm.sh/stable
 
 releases:
   - name: prometheus-redis-exporter

--- a/conf/helmfile.d/0600.prometheus-operator.yaml
+++ b/conf/helmfile.d/0600.prometheus-operator.yaml
@@ -3,6 +3,11 @@ helmDefaults:
   timeout: 600
   force: true
 
+repositories:
+  # Stable repo of official helm charts
+  - name: stable
+    url: https://charts.helm.sh/stable
+
 releases:
 
 #######################################################################################

--- a/conf/helmfile.d/0610.prometheus-adapter.yaml
+++ b/conf/helmfile.d/0610.prometheus-adapter.yaml
@@ -3,6 +3,11 @@ helmDefaults:
   timeout: 600
   force: true
 
+repositories:
+  # Stable repo of official helm charts
+  - name: stable
+    url: https://charts.helm.sh/stable
+
 releases:
 
 ################################################################################

--- a/conf/helmfile.d/9999.openvpn.yaml
+++ b/conf/helmfile.d/9999.openvpn.yaml
@@ -3,6 +3,11 @@ helmDefaults:
   timeout: 600
   force: true
 
+repositories:
+  # Stable repo of official helm charts
+  - name: stable
+    url: https://charts.helm.sh/stable
+
 releases:
 
 ################################################################################


### PR DESCRIPTION
Helm has moved the `stable` repository to `https://charts.helm.sh/stable`. The new repo only supports an archived version and will not receive any patch updates.