### PR TITLE
Skip node-pool destruction during cluster destruction.

### DIFF
--- a/conf/tasks/Makefile.gke
+++ b/conf/tasks/Makefile.gke
@@ -292,7 +292,6 @@ gke/create/all: \
 
 ## Destroy Cluster
 gke/destroy/all: \
-	gke/destroy/node-pools \
 	gke/destroy/cluster \
 	gke/destroy/certifiate-manager-secret \
 	gke/destroy/service-account
@@ -320,7 +319,6 @@ gke/test/create/all: \
 
 ## Destroy Cluster
 gke/test/destroy/all: \
-	gke/destroy/node-pools \
 	gke/destroy/cluster
 	@echo "GKE cluster destroyed"
 	@exit 0


### PR DESCRIPTION
Deleting the node-pools is redundant, as the node-pools are deleted by the `gke/destroy/cluster` command. By skipping this step we can save several minutes of teardown time.

The script and command to delete node-pools will be kept as it works and has utility, but it is just not called during `make gke/destroy/all`.

Fixes #279 