### PR TITLE
Fix helm defaults for ELK helmfiles.

### DIFF
--- a/conf/ELK_helmfiles/0500.elasticsearch.yaml
+++ b/conf/ELK_helmfiles/0500.elasticsearch.yaml
@@ -1,8 +1,3 @@
-helmDefaults:
-  wait: true
-  timeout: 600
-  force: true
-
 repositories:
   # Stable repo of official helm charts
   - name: stable
@@ -28,6 +23,10 @@ releases:
     default: true
   chart: stable/elasticsearch
   version: 1.32.5
+  wait: true
+  timeout: 600
+  atomic: true
+  cleanupOnFail: true
   values:
     - client:
         heapSize: 512m

--- a/conf/ELK_helmfiles/0510.kibana.yaml
+++ b/conf/ELK_helmfiles/0510.kibana.yaml
@@ -1,8 +1,3 @@
-helmDefaults:
-  wait: true
-  timeout: 600
-  force: true
-
 repositories:
   # Stable repo of official helm charts
   - name: stable
@@ -28,6 +23,10 @@ releases:
     default: true
   chart: stable/kibana
   version: 3.2.8
+  wait: true
+  timeout: 300
+  atomic: true
+  cleanupOnFail: true
   values:
     - resources:
         requests:

--- a/conf/ELK_helmfiles/0520.logstash.yaml
+++ b/conf/ELK_helmfiles/0520.logstash.yaml
@@ -1,8 +1,3 @@
-helmDefaults:
-  wait: true
-  timeout: 600
-  force: true
-
 repositories:
   # Stable repo of official helm charts
   - name: stable
@@ -28,6 +23,10 @@ releases:
     default: true
   chart: stable/logstash
   version: 2.4.3
+  wait: true
+  timeout: 300
+  atomic: true
+  cleanupOnFail: true
   values:
     - replicaCount: 4
 

--- a/conf/ELK_helmfiles/0530.filebeat.yaml
+++ b/conf/ELK_helmfiles/0530.filebeat.yaml
@@ -1,8 +1,3 @@
-helmDefaults:
-  wait: true
-  timeout: 600
-  force: true
-
 repositories:
   # Stable repo of official helm charts
   - name: stable
@@ -28,6 +23,10 @@ releases:
     default: true
   chart: stable/filebeat
   version: 4.0.2
+  wait: true
+  timeout: 300
+  atomic: true
+  cleanupOnFail: true
   values:
     - config:
         output.logstash:


### PR DESCRIPTION
Remove the helm defaults and add wait, timeout, atomic, and cleanupOnFail for each release.

These were not updated in #404 