### PR TITLE
Update bucket-monitor helm chart with unified STORAGE_BUCKET variable.

### DIFF
--- a/conf/charts/bucket-monitor/Chart.yaml
+++ b/conf/charts/bucket-monitor/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: bucket-monitor
-version: 0.1.0
+version: 0.2.0
 #kubeVersion: ^1.10.0
 description: This project monitors a cloud bucket (Google or AWS) and waits for files to be uploaded whose names match certain specifictions. These files will have entries written to the cluster's Redis database for them.
 keywords:
@@ -13,6 +13,6 @@ maintainers:
     email: bbannon@caltech.edu
     url: vanvalen.caltech.edu
 engine: gotpl
-appVersion: 0.1.0
+appVersion: 0.4.0
 deprecated: false
 tillerVersion: ^2.9.1

--- a/conf/charts/bucket-monitor/values.yaml
+++ b/conf/charts/bucket-monitor/values.yaml
@@ -12,11 +12,10 @@ image:
 resources: {}
 
 env:
-  DEBUG: "true"
+  LOG_LEVEL: "DEBUG"
   INTERVAL: "21600"
   AGE_THRESHOLD: "604800"
   PREFIX: "uploads/,output/"
-  CLOUD_PROVIDER: "overwrite_this"
-  BUCKET: "overwrite_this"
+  STORAGE_BUCKET: "s3://default-bucket"
   REDIS_HOST: "redis-master"
   REDIS_PORT: "6379"

--- a/conf/helmfile.d/0200.bucket-monitor.yaml
+++ b/conf/helmfile.d/0200.bucket-monitor.yaml
@@ -17,7 +17,7 @@ releases:
     vendor: vanvalenlab
     default: true
   chart: '{{ env "CHARTS_PATH" | default "/conf/charts" }}/bucket-monitor'
-  version: 0.1.0
+  version: 0.2.0
   wait: true
   timeout: 300
   atomic: true
@@ -27,7 +27,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-bucket-monitor
-        tag: 0.3.0
+        tag: 0.4.0
 
       resources:
         requests:
@@ -38,15 +38,13 @@ releases:
         #   memory: 64Mi
 
       env:
-        DEBUG: "true"
         AGE_THRESHOLD: "259200"
         PREFIX: "uploads/,output/"
         INTERVAL: "21600"
         REDIS_HOST: "redis"
         REDIS_PORT: "26379"
-        CLOUD_PROVIDER: {{ env "CLOUD_PROVIDER" | default "broken_default" }}
 {{ if eq (env "CLOUD_PROVIDER" | default "aws") "aws" }}
-        BUCKET: {{ env "BUCKET" | default "broken_default" }}
+        STORAGE_BUCKET: 's3://{{ env "BUCKET" | default "broken_default" }}'
 {{ else }}
-        BUCKET: {{ env "CLOUDSDK_BUCKET" | default "broken_default" }}
+        STORAGE_BUCKET: 'gs://{{ env "CLOUDSDK_BUCKET" | default "broken_default" }}'
 {{ end }}


### PR DESCRIPTION
`kiosk-bucket-monitor` version 0.4.0 combines `BUCKET` and `CLOUD_PROVIDER` into a unified `STORAGE_BUCKET` environment variable which includes the bucket protocol (e.g. `gs://bucket`). Additionally, `DEBUG` has been removed in favor of `LOG_LEVEL`.

The chart has been updated to reflect these changes in environment variables.