### PR TITLE
Add more cluster specific details to the bug report template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,6 +12,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Run '...'
 2. Enter '....'
 3. See error
@@ -22,9 +23,19 @@ A clear and concise description of what you expected to happen.
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
- - OS: [e.g. macOS, Ubuntu]
- - Version [e.g. 22]
+**Ennvironment:**
+
+- OS: [e.g. macOS, Ubuntu]
+- Kiosk version: [e.g. 1.4.0]
+- `kubectl version`:
+- `helm version`:
+- `helmfile version`:
 
 **Additional context**
 Add any other context about the problem here.
+
+If the bug is about the behavior of a pod, please include:
+
+- currently running pods [e.g. `kubectl get po`]
+- details of the failed pod [e.g. `kubectl describe po [pod_name]`]
+- pod output before failure [e.g. `kubectl logs [pod_name]`].


### PR DESCRIPTION
Prompt user for information about the cloud tools they are using (`kubectl`, `helm` and `helmfile`) in addition to any pod specific details (`kubectl describe pod` and `kubectl logs pod`).

Fixes #285 