### PR TITLE
Update autoscaler and janitor for better 1.16 compatibility.

### DIFF
--- a/conf/helmfile.d/0210.autoscaler.yaml
+++ b/conf/helmfile.d/0210.autoscaler.yaml
@@ -27,7 +27,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-autoscaler
-        tag: 0.4.1
+        tag: 0.5.0
 
       resources:
         requests:

--- a/conf/helmfile.d/0220.redis-janitor.yaml
+++ b/conf/helmfile.d/0220.redis-janitor.yaml
@@ -27,7 +27,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-janitor
-        tag: 0.3.2
+        tag: 0.4.0
 
       resources:
         requests:


### PR DESCRIPTION
Both new versions use `kubernetes` 12.0.1 which has been built for Kubernetes 1.16.