### PR TITLE
Quote all annotations in chart templates.

### DIFF
--- a/conf/charts/frontend/Chart.yaml
+++ b/conf/charts/frontend/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: frontend
-version: 0.2.1
+version: 0.2.2
 #kubeVersion: ^1.9.8
 description: This project provides the frontend interface for the Tensorflow-serving backend of Deepcell.
 keywords:

--- a/conf/charts/frontend/templates/ingress.yaml
+++ b/conf/charts/frontend/templates/ingress.yaml
@@ -11,9 +11,10 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-{{- if .Values.service.annotations }}
-  annotations:
-{{ toYaml .Values.service.annotations | indent 4 }}
+{{- range $name, $value := .Values.ingress.annotations }}
+{{- if not ( empty $value) }}
+    {{ $name }}: {{ $value | quote }}
+{{- end }}
 {{- end }}
 spec:
   rules:

--- a/conf/charts/frontend/templates/service.yaml
+++ b/conf/charts/frontend/templates/service.yaml
@@ -7,9 +7,11 @@ metadata:
     chart: {{ template "chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- if .Values.service.annotations }}
   annotations:
-{{ toYaml .Values.service.annotations | indent 4 }}
+{{- range $name, $value := .Values.ingress.annotations }}
+{{- if not ( empty $value) }}
+    {{ $name }}: {{ $value | quote }}
+{{- end }}
 {{- end }}
 spec:
   type: {{ .Values.service.type }}

--- a/conf/charts/frontend/templates/service.yaml
+++ b/conf/charts/frontend/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-{{- range $name, $value := .Values.ingress.annotations }}
+{{- range $name, $value := .Values.service.annotations }}
 {{- if not ( empty $value) }}
     {{ $name }}: {{ $value | quote }}
 {{- end }}

--- a/conf/charts/redis-consumer/Chart.yaml
+++ b/conf/charts/redis-consumer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis-consumer
-version: 0.3.0
+version: 0.3.1
 #kubeVersion: ^1.9.8
 description: This project consumes and processes redis event, placing the final result back to redis.
 keywords:

--- a/conf/charts/redis-consumer/templates/service.yaml
+++ b/conf/charts/redis-consumer/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: {{ template "fullname" . }}
   annotations:
-{{- range $name, $value := .Values.ingress.annotations }}
+{{- range $name, $value := .Values.service.annotations }}
 {{- if not ( empty $value) }}
     {{ $name }}: {{ $value | quote }}
 {{- end }}

--- a/conf/charts/redis-consumer/templates/service.yaml
+++ b/conf/charts/redis-consumer/templates/service.yaml
@@ -4,9 +4,11 @@ metadata:
   name: {{ template "fullname" . }}
   labels:
     app: {{ template "fullname" . }}
-{{- if .Values.service.annotations }}
   annotations:
-{{ toYaml .Values.service.annotations | indent 4 }}
+{{- range $name, $value := .Values.ingress.annotations }}
+{{- if not ( empty $value) }}
+    {{ $name }}: {{ $value | quote }}
+{{- end }}
 {{- end }}
 spec:
   type: {{ .Values.service.type }}

--- a/conf/charts/tf-serving/Chart.yaml
+++ b/conf/charts/tf-serving/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: tf-serving
-version: 0.4.0
+version: 0.4.1
 #kubeVersion: ^1.9.8
 description: This helm chart provides the Tensorflow-serving backend functionality of the Deepcell application.
 keywords:

--- a/conf/charts/tf-serving/templates/deployment.yaml
+++ b/conf/charts/tf-serving/templates/deployment.yaml
@@ -16,7 +16,11 @@ spec:
   template:
     metadata:
       annotations:
-{{ toYaml .Values.annotations | indent 8 }}
+{{- range $name, $value := .Values.annotations }}
+{{- if not ( empty $value) }}
+        {{ $name }}: {{ $value | quote }}
+{{- end }}
+{{- end }}
       labels:
         app: {{ template "name" . }}
         release: {{ .Release.Name }}

--- a/conf/charts/tf-serving/templates/service.yaml
+++ b/conf/charts/tf-serving/templates/service.yaml
@@ -7,9 +7,11 @@ metadata:
     release: {{ .Release.Name | quote }}
     chart: {{ template "chart" . }}
     app: {{ template "name" . }}
-{{- if .Values.service.annotations }}
   annotations:
-{{ toYaml .Values.service.annotations | indent 4 }}
+{{- range $name, $value := .Values.service.annotations }}
+{{- if not ( empty $value) }}
+    {{ $name }}: {{ $value | quote }}
+{{- end }}
 {{- end }}
 spec:
   type: {{ .Values.service.type }}


### PR DESCRIPTION
Annotations must be strings! Unquoted booleans or numbers can be ignored, causing unexpected behavior. This PR updates several charts to ensure that annotations on services, ingresses, and deployments are quoted.

- `frontend/ingress`
- `frontend/service`
- `redis-consumer/service`
- `tf-serving/deployment`
- `tf-serving/service`