### PR TITLE
Update all consumers to version 0.10.0.

### DIFF
--- a/conf/charts/redis-consumer/Chart.yaml
+++ b/conf/charts/redis-consumer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis-consumer
-version: 0.3.1
+version: 0.4.0
 #kubeVersion: ^1.9.8
 description: This project consumes and processes redis event, placing the final result back to redis.
 keywords:
@@ -13,6 +13,6 @@ maintainers:
     email: bbannon@caltech.edu
     url: vanvalen.caltech.edu
 engine: gotpl
-appVersion: 0.9.0
+appVersion: 0.10.0
 deprecated: false
 tillerVersion: ^2.9.1

--- a/conf/charts/redis-consumer/values.yaml
+++ b/conf/charts/redis-consumer/values.yaml
@@ -36,7 +36,7 @@ hpa:
 env:
   LOG_LEVEL: "DEBUG"
   INTERVAL: 10
-  CONSUMER_TYPE: "image"
+  CONSUMER_TYPE: "segmentation"
   QUEUE: "segmentation"
   SEGMENTATION_QUEUE: "segmentation"
   EMPTY_QUEUE_TIMEOUT: 5
@@ -51,28 +51,25 @@ env:
   REDIS_PORT: "6379"
   REDIS_TIMEOUT: 3
 
-  TF_HOST: "overwrite_this"
-  TF_PORT: "sepcify_me"
+  TF_HOST: "tf-serving"
+  TF_PORT: 8500
   TF_MAX_BATCH_SIZE: 1
   TF_MIN_MODEL_SIZE: 128
 
   AWS_REGION: "us-east-1"
   GKE_COMPUTE_ZONE: "us-west1-b"
 
-  NUCLEAR_MODEL: "NuclearSegmentation:0"
-  NUCLEAR_POSTPROCESS: "deep_watershed"
+  NUCLEAR_MODEL: "NuclearSegmentation:3"
 
   PHASE_MODEL: "PhaseCytoSegmentation:0"
-  PHASE_POSTPROCESS: "deep_watershed"
 
-  CYTOPLASM_MODEL: "FluoCytoSegmentation:0"
-  CYTOPLASM_POSTPROCESS: "deep_watershed"
+  CYTOPLASM_MODEL: "FluoCytoSegmentation:1"
 
   LABEL_DETECT_ENABLED: "false"
-  LABEL_DETECT_MODEL: "LabelDetection:0"
+  LABEL_DETECT_MODEL: "LabelDetection:1"
 
   SCALE_DETECT_ENABLED: "false"
-  SCALE_DETECT_MODEL: "ScaleDetection:0"
+  SCALE_DETECT_MODEL: "ScaleDetection:1"
 
   DRIFT_CORRECT_ENABLED: "false"
   NORMALIZE_TRACKING: "false"

--- a/conf/helmfile.d/0230.segmentation-consumer.yaml
+++ b/conf/helmfile.d/0230.segmentation-consumer.yaml
@@ -17,7 +17,7 @@ releases:
     vendor: vanvalenlab
     default: true
   chart: '{{ env "CHARTS_PATH" | default "/conf/charts" }}/redis-consumer'
-  version: 0.3.0
+  version: 0.4.0
   wait: true
   timeout: 300
   atomic: true

--- a/conf/helmfile.d/0230.segmentation-consumer.yaml
+++ b/conf/helmfile.d/0230.segmentation-consumer.yaml
@@ -64,7 +64,7 @@ releases:
       env:
         INTERVAL: 1
         QUEUE: "segmentation"
-        CONSUMER_TYPE: "image"
+        CONSUMER_TYPE: "segmentation"
         EMPTY_QUEUE_TIMEOUT: 5
         GRPC_TIMEOUT: 20
         GRPC_BACKOFF: 3
@@ -82,20 +82,17 @@ releases:
         AWS_REGION: '{{ env "AWS_REGION" | default "us-east-1" }}'
         GKE_COMPUTE_ZONE: '{{ env "GKE_COMPUTE_ZONE" | default "us-west1-b" }}'
 
-        NUCLEAR_MODEL: "NuclearSegmentation:0"
-        NUCLEAR_POSTPROCESS: "deep_watershed"
+        NUCLEAR_MODEL: "NuclearSegmentation:3"
 
         PHASE_MODEL: "PhaseCytoSegmentation:0"
-        PHASE_POSTPROCESS: "deep_watershed"
 
-        CYTOPLASM_MODEL: "FluoCytoSegmentation:0"
-        CYTOPLASM_POSTPROCESS: "deep_watershed"
+        CYTOPLASM_MODEL: "FluoCytoSegmentation:1"
 
-        LABEL_DETECT_ENABLED: "true"
-        LABEL_DETECT_MODEL: "LabelDetection:0"
+        LABEL_DETECT_ENABLED: "false"
+        LABEL_DETECT_MODEL: "LabelDetection:1"
 
-        SCALE_DETECT_ENABLED: "true"
-        SCALE_DETECT_MODEL: "ScaleDetection:0"
+        SCALE_DETECT_ENABLED: "false"
+        SCALE_DETECT_MODEL: "ScaleDetection:1"
 
       secrets:
         AWS_ACCESS_KEY_ID: '{{ env "AWS_ACCESS_KEY_ID" | default "NA" }}'

--- a/conf/helmfile.d/0230.segmentation-consumer.yaml
+++ b/conf/helmfile.d/0230.segmentation-consumer.yaml
@@ -27,7 +27,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.9.0
+        tag: 0.10.0
 
       nameOverride: segmentation-consumer
 

--- a/conf/helmfile.d/0231.segmentation-zip-consumer.yaml
+++ b/conf/helmfile.d/0231.segmentation-zip-consumer.yaml
@@ -17,7 +17,7 @@ releases:
     vendor: vanvalenlab
     default: true
   chart: '{{ env "CHARTS_PATH" | default "/conf/charts" }}/redis-consumer'
-  version: 0.3.0
+  version: 0.4.0
   wait: true
   timeout: 300
   atomic: true

--- a/conf/helmfile.d/0231.segmentation-zip-consumer.yaml
+++ b/conf/helmfile.d/0231.segmentation-zip-consumer.yaml
@@ -63,15 +63,13 @@ releases:
 
       env:
         QUEUE: "segmentation"
+        CONSUMER_TYPE: "zip"
         REDIS_HOST: "redis"
         REDIS_PORT: "26379"
         TF_HOST: "tf-serving"
         TF_PORT: "8500"
         AWS_REGION: '{{ env "AWS_REGION" | default "us-east-1" }}'
         GKE_COMPUTE_ZONE: '{{ env "GKE_COMPUTE_ZONE" | default "us-west1-b" }}'
-        CONSUMER_TYPE: "zip"
-        LABEL_DETECT_ENABLED: "true"
-        SCALE_DETECT_ENABLED: "true"
 
       secrets:
         AWS_ACCESS_KEY_ID: '{{ env "AWS_ACCESS_KEY_ID" | default "NA" }}'

--- a/conf/helmfile.d/0231.segmentation-zip-consumer.yaml
+++ b/conf/helmfile.d/0231.segmentation-zip-consumer.yaml
@@ -27,7 +27,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.9.0
+        tag: 0.10.0
 
       nameOverride: segmentation-zip-consumer
 

--- a/conf/helmfile.d/0250.tracking-consumer.yaml
+++ b/conf/helmfile.d/0250.tracking-consumer.yaml
@@ -17,7 +17,7 @@ releases:
     vendor: vanvalenlab
     default: true
   chart: '{{ env "CHARTS_PATH" | default "/conf/charts" }}/redis-consumer'
-  version: 0.3.0
+  version: 0.4.0
   wait: true
   timeout: 300
   atomic: true

--- a/conf/helmfile.d/0250.tracking-consumer.yaml
+++ b/conf/helmfile.d/0250.tracking-consumer.yaml
@@ -83,20 +83,17 @@ releases:
         AWS_REGION: '{{ env "AWS_REGION" | default "us-east-1" }}'
         GKE_COMPUTE_ZONE: '{{ env "GKE_COMPUTE_ZONE" | default "us-west1-b" }}'
 
-        NUCLEAR_MODEL: "NuclearSegmentation:0"
-        NUCLEAR_POSTPROCESS: "deep_watershed"
+        NUCLEAR_MODEL: "NuclearSegmentation:3"
 
         PHASE_MODEL: "PhaseCytoSegmentation:0"
-        PHASE_POSTPROCESS: "deep_watershed"
 
-        CYTOPLASM_MODEL: "FluoCytoSegmentation:0"
-        CYTOPLASM_POSTPROCESS: "deep_watershed"
+        CYTOPLASM_MODEL: "FluoCytoSegmentation:1"
 
-        LABEL_DETECT_ENABLED: "true"
-        LABEL_DETECT_MODEL: "LabelDetection:0"
+        LABEL_DETECT_ENABLED: "false"
+        LABEL_DETECT_MODEL: "LabelDetection:1"
 
-        SCALE_DETECT_ENABLED: "true"
-        SCALE_DETECT_MODEL: "ScaleDetection:0"
+        SCALE_DETECT_ENABLED: "false"
+        SCALE_DETECT_MODEL: "ScaleDetection:1"
 
         TRACKING_MODEL: "tracking_model_benchmarking_757_step5_20epoch_80split_9tl:1"
         DRIFT_CORRECT_ENABLED: "false"

--- a/conf/helmfile.d/0250.tracking-consumer.yaml
+++ b/conf/helmfile.d/0250.tracking-consumer.yaml
@@ -27,7 +27,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.9.0
+        tag: 0.10.0
 
       nameOverride: tracking-consumer
 

--- a/conf/helmfile.d/0251.tracking-zip-consumer.yaml
+++ b/conf/helmfile.d/0251.tracking-zip-consumer.yaml
@@ -17,7 +17,7 @@ releases:
     vendor: vanvalenlab
     default: true
   chart: '{{ env "CHARTS_PATH" | default "/conf/charts" }}/redis-consumer'
-  version: 0.3.0
+  version: 0.4.0
   wait: true
   timeout: 300
   atomic: true

--- a/conf/helmfile.d/0251.tracking-zip-consumer.yaml
+++ b/conf/helmfile.d/0251.tracking-zip-consumer.yaml
@@ -27,7 +27,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.9.0
+        tag: 0.10.0
 
       nameOverride: tracking-zip-consumer
 

--- a/conf/helmfile.d/0251.tracking-zip-consumer.yaml
+++ b/conf/helmfile.d/0251.tracking-zip-consumer.yaml
@@ -63,15 +63,13 @@ releases:
 
       env:
         QUEUE: "tracking"
+        CONSUMER_TYPE: "zip"
         REDIS_HOST: "redis"
         REDIS_PORT: "26379"
         TF_HOST: "tf-serving"
         TF_PORT: "8500"
         AWS_REGION: '{{ env "AWS_REGION" | default "us-east-1" }}'
         GKE_COMPUTE_ZONE: '{{ env "GKE_COMPUTE_ZONE" | default "us-west1-b" }}'
-        CONSUMER_TYPE: "zip"
-        LABEL_DETECT_ENABLED: "true"
-        SCALE_DETECT_ENABLED: "true"
 
       secrets:
         AWS_ACCESS_KEY_ID: '{{ env "AWS_ACCESS_KEY_ID" | default "NA" }}'

--- a/conf/helmfile.d/0260.mesmer-consumer.yaml
+++ b/conf/helmfile.d/0260.mesmer-consumer.yaml
@@ -17,7 +17,7 @@ releases:
     vendor: vanvalenlab
     default: true
   chart: '{{ env "CHARTS_PATH" | default "/conf/charts" }}/redis-consumer'
-  version: 0.3.0
+  version: 0.4.0
   values:
     - replicas: 1
 

--- a/conf/helmfile.d/0261.mesmer-zip-consumer.yaml
+++ b/conf/helmfile.d/0261.mesmer-zip-consumer.yaml
@@ -23,7 +23,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.9.0
+        tag: 0.10.0
 
       nameOverride: mesmer-zip-consumer
 

--- a/conf/helmfile.d/0261.mesmer-zip-consumer.yaml
+++ b/conf/helmfile.d/0261.mesmer-zip-consumer.yaml
@@ -17,7 +17,7 @@ releases:
     vendor: vanvalenlab
     default: true
   chart: '{{ env "CHARTS_PATH" | default "/conf/charts" }}/redis-consumer'
-  version: 0.3.0
+  version: 0.4.0
   values:
     - replicas: 1
 

--- a/conf/helmfile.d/0261.mesmer-zip-consumer.yaml
+++ b/conf/helmfile.d/0261.mesmer-zip-consumer.yaml
@@ -59,6 +59,7 @@ releases:
 
       env:
         QUEUE: "mesmer"
+        CONSUMER_TYPE: "zip"
         REDIS_HOST: "redis"
         REDIS_PORT: "26379"
         TF_HOST: "tf-serving"
@@ -66,9 +67,6 @@ releases:
         DEBUG: "true"
         AWS_REGION: '{{ env "AWS_REGION" | default "us-east-1" }}'
         GKE_COMPUTE_ZONE: '{{ env "GKE_COMPUTE_ZONE" | default "us-west1-b" }}'
-        CONSUMER_TYPE: "zip"
-        LABEL_DETECT_ENABLED: "true"
-        SCALE_DETECT_ENABLED: "true"
 
       secrets:
         AWS_ACCESS_KEY_ID: '{{ env "AWS_ACCESS_KEY_ID" | default "NA" }}'


### PR DESCRIPTION
- Remove unused environment variables from helm chart.
- Update default `CONSUMER_TYPE`, as `"image"` is a deprecated value.
- Update `redis-consumer` helm chart to version 0.4.0 and appVersion to 0.10.0.
- Update model versions defined in helmfiles to match `deepcell-models` bucket.