### PR TITLE
Bump frontend chart to 0.3.0 and redis-consumer chart to 0.5.0

### DIFF
--- a/conf/charts/frontend/Chart.yaml
+++ b/conf/charts/frontend/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: frontend
-version: 0.2.2
+version: 0.3.0
 #kubeVersion: ^1.9.8
 description: This project provides the frontend interface for the Tensorflow-serving backend of Deepcell.
 keywords:
@@ -13,6 +13,6 @@ maintainers:
     email: bbannon@caltech.edu
     url: vanvalen.caltech.edu
 engine: gotpl
-appVersion: 0.6.0
+appVersion: 0.7.0
 deprecated: false
 tillerVersion: ^2.9.1

--- a/conf/charts/frontend/values.yaml
+++ b/conf/charts/frontend/values.yaml
@@ -6,7 +6,7 @@ replicas: 1
 
 image:
   repository: vanvalenlab/kiosk-frontend
-  tag: 0.6.0
+  tag: 0.7.0
   pullPolicy: IfNotPresent
 
 ingress:

--- a/conf/charts/redis-consumer/Chart.yaml
+++ b/conf/charts/redis-consumer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis-consumer
-version: 0.4.0
+version: 0.5.0
 #kubeVersion: ^1.9.8
 description: This project consumes and processes redis event, placing the final result back to redis.
 keywords:
@@ -13,6 +13,6 @@ maintainers:
     email: bbannon@caltech.edu
     url: vanvalen.caltech.edu
 engine: gotpl
-appVersion: 0.10.0
+appVersion: 0.11.0
 deprecated: false
 tillerVersion: ^2.9.1

--- a/conf/charts/redis-consumer/values.yaml
+++ b/conf/charts/redis-consumer/values.yaml
@@ -6,7 +6,7 @@ replicas: 1
 
 image:
   repository: vanvalenlab/kiosk-redis-consumer
-  tag: 0.9.0
+  tag: 0.11.0
   pullPolicy: IfNotPresent
 
 resources: {}

--- a/conf/helmfile.d/0230.segmentation-consumer.yaml
+++ b/conf/helmfile.d/0230.segmentation-consumer.yaml
@@ -17,7 +17,7 @@ releases:
     vendor: vanvalenlab
     default: true
   chart: '{{ env "CHARTS_PATH" | default "/conf/charts" }}/redis-consumer'
-  version: 0.4.0
+  version: 0.5.0
   wait: true
   timeout: 300
   atomic: true
@@ -27,7 +27,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.10.0
+        tag: 0.11.0
 
       nameOverride: segmentation-consumer
 

--- a/conf/helmfile.d/0231.segmentation-zip-consumer.yaml
+++ b/conf/helmfile.d/0231.segmentation-zip-consumer.yaml
@@ -17,7 +17,7 @@ releases:
     vendor: vanvalenlab
     default: true
   chart: '{{ env "CHARTS_PATH" | default "/conf/charts" }}/redis-consumer'
-  version: 0.4.0
+  version: 0.5.0
   wait: true
   timeout: 300
   atomic: true
@@ -27,7 +27,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.10.0
+        tag: 0.11.0
 
       nameOverride: segmentation-zip-consumer
 

--- a/conf/helmfile.d/0250.tracking-consumer.yaml
+++ b/conf/helmfile.d/0250.tracking-consumer.yaml
@@ -17,7 +17,7 @@ releases:
     vendor: vanvalenlab
     default: true
   chart: '{{ env "CHARTS_PATH" | default "/conf/charts" }}/redis-consumer'
-  version: 0.4.0
+  version: 0.5.0
   wait: true
   timeout: 300
   atomic: true
@@ -27,7 +27,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.10.0
+        tag: 0.11.0
 
       nameOverride: tracking-consumer
 

--- a/conf/helmfile.d/0251.tracking-zip-consumer.yaml
+++ b/conf/helmfile.d/0251.tracking-zip-consumer.yaml
@@ -17,7 +17,7 @@ releases:
     vendor: vanvalenlab
     default: true
   chart: '{{ env "CHARTS_PATH" | default "/conf/charts" }}/redis-consumer'
-  version: 0.4.0
+  version: 0.5.0
   wait: true
   timeout: 300
   atomic: true
@@ -27,7 +27,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.10.0
+        tag: 0.11.0
 
       nameOverride: tracking-zip-consumer
 

--- a/conf/helmfile.d/0260.mesmer-consumer.yaml
+++ b/conf/helmfile.d/0260.mesmer-consumer.yaml
@@ -17,13 +17,13 @@ releases:
     vendor: vanvalenlab
     default: true
   chart: '{{ env "CHARTS_PATH" | default "/conf/charts" }}/redis-consumer'
-  version: 0.4.0
+  version: 0.5.0
   values:
     - replicas: 1
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.10.0
+        tag: 0.11.0
 
       nameOverride: mesmer-consumer
 

--- a/conf/helmfile.d/0261.mesmer-zip-consumer.yaml
+++ b/conf/helmfile.d/0261.mesmer-zip-consumer.yaml
@@ -17,13 +17,13 @@ releases:
     vendor: vanvalenlab
     default: true
   chart: '{{ env "CHARTS_PATH" | default "/conf/charts" }}/redis-consumer'
-  version: 0.4.0
+  version: 0.5.0
   values:
     - replicas: 1
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.10.0
+        tag: 0.11.0
 
       nameOverride: mesmer-zip-consumer
 

--- a/conf/helmfile.d/0300.frontend.yaml
+++ b/conf/helmfile.d/0300.frontend.yaml
@@ -17,7 +17,7 @@ releases:
     vendor: vanvalenlab
     default: true
   chart: '{{ env "CHARTS_PATH" | default "/conf/charts" }}/frontend'
-  version: 0.2.1
+  version: 0.3.0
   wait: true
   timeout: 300
   atomic: true
@@ -27,7 +27,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-frontend
-        tag: 0.6.0
+        tag: 0.7.0
 
       resources:
         requests:


### PR DESCRIPTION
Updates app version for frontend to 0.7.0 and redis-consumer to 0.11.0.