### PR TITLE
Update `autoscaler` and `redis-janitor` for better GKE 1.17 compatibility.

### DIFF
--- a/conf/helmfile.d/0210.autoscaler.yaml
+++ b/conf/helmfile.d/0210.autoscaler.yaml
@@ -27,7 +27,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-autoscaler
-        tag: 0.5.0
+        tag: 0.6.0
 
       resources:
         requests:

--- a/conf/helmfile.d/0220.redis-janitor.yaml
+++ b/conf/helmfile.d/0220.redis-janitor.yaml
@@ -27,7 +27,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-janitor
-        tag: 0.4.0
+        tag: 0.5.0
 
       resources:
         requests:


### PR DESCRIPTION
Upgrade versions of both `autoscaler` and `redis-janitor` to use `kubernetes` 17.17.0 with GKE 1.17 support.