### PR TITLE
Bump kiosk-redis-consumer image to 0.16.2

### DIFF
--- a/conf/helmfile.d/0230.segmentation-consumer.yaml
+++ b/conf/helmfile.d/0230.segmentation-consumer.yaml
@@ -27,7 +27,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.16.1
+        tag: 0.16.2
 
       nameOverride: segmentation-consumer
 

--- a/conf/helmfile.d/0231.segmentation-zip-consumer.yaml
+++ b/conf/helmfile.d/0231.segmentation-zip-consumer.yaml
@@ -27,7 +27,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.16.1
+        tag: 0.16.2
 
       nameOverride: segmentation-zip-consumer
 

--- a/conf/helmfile.d/0250.caliban-consumer.yaml
+++ b/conf/helmfile.d/0250.caliban-consumer.yaml
@@ -27,7 +27,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.16.1
+        tag: 0.16.2
 
       nameOverride: caliban-consumer
 

--- a/conf/helmfile.d/0251.caliban-zip-consumer.yaml
+++ b/conf/helmfile.d/0251.caliban-zip-consumer.yaml
@@ -27,7 +27,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.16.1
+        tag: 0.16.2
 
       nameOverride: caliban-zip-consumer
 

--- a/conf/helmfile.d/0260.mesmer-consumer.yaml
+++ b/conf/helmfile.d/0260.mesmer-consumer.yaml
@@ -23,7 +23,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.16.1
+        tag: 0.16.2
 
       nameOverride: mesmer-consumer
 

--- a/conf/helmfile.d/0261.mesmer-zip-consumer.yaml
+++ b/conf/helmfile.d/0261.mesmer-zip-consumer.yaml
@@ -23,7 +23,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.16.1
+        tag: 0.16.2
 
       nameOverride: mesmer-zip-consumer
 

--- a/conf/helmfile.d/0270.polaris-consumer.yaml
+++ b/conf/helmfile.d/0270.polaris-consumer.yaml
@@ -23,7 +23,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.16.1
+        tag: 0.16.2
 
       nameOverride: polaris-consumer
 

--- a/conf/helmfile.d/0271.polaris-zip-consumer.yaml
+++ b/conf/helmfile.d/0271.polaris-zip-consumer.yaml
@@ -23,7 +23,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.16.1
+        tag: 0.16.2
 
       nameOverride: polaris-zip-consumer
 

--- a/conf/helmfile.d/0280.spot-consumer.yaml
+++ b/conf/helmfile.d/0280.spot-consumer.yaml
@@ -23,7 +23,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.16.1
+        tag: 0.16.2
 
       nameOverride: spot-consumer
 

--- a/conf/helmfile.d/0281.spot-zip-consumer.yaml
+++ b/conf/helmfile.d/0281.spot-zip-consumer.yaml
@@ -23,7 +23,7 @@ releases:
 
       image:
         repository: vanvalenlab/kiosk-redis-consumer
-        tag: 0.16.1
+        tag: 0.16.2
 
       nameOverride: spot-zip-consumer
 


### PR DESCRIPTION
Contains the fix for LZW compression