### PR TITLE
Change redis chart repo to bitnami-pre-2022

### DIFF
--- a/conf/helmfile.d/0100.redis.yaml
+++ b/conf/helmfile.d/0100.redis.yaml
@@ -1,6 +1,6 @@
 repositories:
-  - name: bitnami
-    url: https://charts.bitnami.com/bitnami
+  - name: bitnami-pre-2022
+    url: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
 
 releases:
 
@@ -16,7 +16,7 @@ releases:
   labels:
     chart: redis
     component: database
-  chart: bitnami/redis
+  chart: bitnami-pre-2022/redis
   version: 10.5.7
   namespace: deepcell
   wait: true


### PR DESCRIPTION
Bitnami moved all pre-2022 charts into a new repo as described in this issue https://github.com/bitnami/charts/issues/10539. This PR changes the repo for the redis chart so that we can retain access to the same version of the chart that we have been using.