### PR TITLE
chore: upgrade geodesic base image version (#464)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,7 +26,7 @@ If applicable, add screenshots to help explain your problem.
 **Ennvironment:**
 
 - OS: [e.g. macOS, Ubuntu]
-- Kiosk version: [e.g. 1.8.0]
+- Kiosk version: [e.g. 1.8.1]
 - `kubectl version`:
 - `helm version`:
 - `helmfile version`:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,28 @@
-FROM cloudposse/build-harness:0.39.0 as build-harness
+FROM cloudposse/build-harness:1.3.0 as build-harness
 
-FROM cloudposse/geodesic:0.135.0
+FROM cloudposse/geodesic:1.2.1-alpine
 
 RUN apk add --update dialog libqrencode
 
 ENV DOCKER_IMAGE="vanvalenlab/kiosk-console"
 ENV DOCKER_TAG="latest"
 
-# Geodesic banner
+# Banner is what is displayed at startup and on every command line
+# in order to distinguish this image from other similar images
 ENV BANNER="deepcell"
 ENV BANNER_FONT="Larry 3D 2.flf"
 
-# Disable cloudposse motd
+# Disable message of the day
 ENV MOTD_URL=""
+
+# Shell customization
+# options for `less`. `R` allows ANSI color codes to be displayed while stripping out
+# other control codes that can cause `less` to mess up the screen formatting
+ENV LESS=R
+
+# Enable `direnv`
+# TODO: Use preferring YAML configuration files instead.
+ENV DIRENV_ENABLED=true
 
 # Silence make
 ENV MAKE="make -s"
@@ -50,6 +60,9 @@ ENV GCP_TRAINING_GPU_TYPE="nvidia-tesla-v100"
 ENV GKE_MACHINE_TYPE="n1-standard-1"
 ENV GPU_MACHINE_TYPE="n1-highmem-2"
 ENV CONSUMER_MACHINE_TYPE="n1-standard-2"
+# gcp auth plugin is deprecated as of k8s 1.22, use the gke auth plugin instead
+# https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
+ENV USE_GKE_GCLOUD_AUTH_PLUGIN="false"
 
 # Deployment config
 ENV CLOUD_PROVIDER=""
@@ -78,4 +91,4 @@ COPY rootfs/ /
 # Enable the menu
 RUN ln -s /usr/local/bin/menu.sh /etc/profile.d/ΩΩ.menu.sh
 
-WORKDIR /conf/
+ENV GEODESIC_WORKDIR=/conf

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Tracked Image
 Start a terminal shell and install the DeepCell Kiosk wrapper script:
 
 ```bash
-docker run -e DOCKER_TAG=1.8.0 vanvalenlab/kiosk-console:1.8.0 | sudo bash
+docker run -e DOCKER_TAG=1.8.1 vanvalenlab/kiosk-console:1.8.1 | sudo bash
 ```
 
 To start the kiosk, just run `kiosk-console` from the terminal shell.

--- a/conf/charts/frontend/templates/hpa.yaml
+++ b/conf/charts/frontend/templates/hpa.yaml
@@ -1,8 +1,6 @@
 {{- if (.Values.hpa.enabled) }}
 ---
-apiVersion: autoscaling/v2beta1
-kind: HorizontalPodAutoscaler
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "fullname" . }}

--- a/conf/charts/redis-consumer/templates/hpa.yaml
+++ b/conf/charts/redis-consumer/templates/hpa.yaml
@@ -1,8 +1,6 @@
 {{- if (.Values.hpa.enabled) }}
 ---
-apiVersion: autoscaling/v2beta1
-kind: HorizontalPodAutoscaler
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "fullname" . }}

--- a/conf/charts/tf-serving/templates/hpa.yaml
+++ b/conf/charts/tf-serving/templates/hpa.yaml
@@ -1,8 +1,6 @@
 {{- if (.Values.hpa.enabled) }}
 ---
-apiVersion: autoscaling/v2beta1
-kind: HorizontalPodAutoscaler
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "fullname" . }}

--- a/conf/helmfile.d/0230.segmentation-consumer.yaml
+++ b/conf/helmfile.d/0230.segmentation-consumer.yaml
@@ -54,12 +54,15 @@ releases:
         metrics:
         - type: Object
           object:
-            metricName: segmentation_consumer_key_ratio
-            target:
-              apiVersion: v1
+            describedObject:
               kind: Namespace
               name: segmentation_consumer_key_ratio
-            targetValue: .15
+              apiVersion: v1
+            metric:
+              name: segmentation_consumer_key_ratio
+            target:
+              type: Value
+              value: .15
 
       env:
         INTERVAL: 1

--- a/conf/helmfile.d/0231.segmentation-zip-consumer.yaml
+++ b/conf/helmfile.d/0231.segmentation-zip-consumer.yaml
@@ -54,13 +54,15 @@ releases:
         metrics:
         - type: Object
           object:
-            metricName: segmentation_zip_consumer_key_ratio
-            target:
-              apiVersion: v1
+            describedObject:
               kind: Namespace
-              name: segmentation_zip_consumer_key_ratio
-            targetValue: 2
-
+              name: segmentation_consumer_key_ratio
+              apiVersion: v1
+            metric:
+              name: segmentation_consumer_key_ratio
+            target:
+              type: Value
+              value: .15
       env:
         QUEUE: "segmentation"
         CONSUMER_TYPE: "zip"

--- a/conf/helmfile.d/0250.caliban-consumer.yaml
+++ b/conf/helmfile.d/0250.caliban-consumer.yaml
@@ -54,12 +54,15 @@ releases:
         metrics:
         - type: Object
           object:
-            metricName: caliban_consumer_key_ratio
-            target:
-              apiVersion: v1
+            describedObject:
               kind: Namespace
               name: caliban_consumer_key_ratio
-            targetValue: 1
+              apiVersion: v1
+            metric:
+              name: caliban_consumer_key_ratio
+            target:
+              type: Value
+              value: 1
 
       env:
         INTERVAL: 1

--- a/conf/helmfile.d/0251.caliban-zip-consumer.yaml
+++ b/conf/helmfile.d/0251.caliban-zip-consumer.yaml
@@ -54,12 +54,15 @@ releases:
         metrics:
         - type: Object
           object:
-            metricName: caliban_zip_consumer_key_ratio
-            target:
-              apiVersion: v1
+            describedObject:
               kind: Namespace
               name: caliban_zip_consumer_key_ratio
-            targetValue: 2
+              apiVersion: v1
+            metric:
+              name: caliban_zip_consumer_key_ratio
+            target:
+              type: Value
+              value: 2
 
       env:
         QUEUE: "caliban"

--- a/conf/helmfile.d/0260.mesmer-consumer.yaml
+++ b/conf/helmfile.d/0260.mesmer-consumer.yaml
@@ -50,12 +50,15 @@ releases:
         metrics:
         - type: Object
           object:
-            metricName: mesmer_consumer_key_ratio
-            target:
-              apiVersion: v1
+            describedObject:
               kind: Namespace
               name: mesmer_consumer_key_ratio
-            targetValue: 1
+              apiVersion: v1
+            metric:
+              name: mesmer_consumer_key_ratio
+            target:
+              type: Value
+              value: 1
 
       env:
         INTERVAL: 1

--- a/conf/helmfile.d/0261.mesmer-zip-consumer.yaml
+++ b/conf/helmfile.d/0261.mesmer-zip-consumer.yaml
@@ -50,12 +50,15 @@ releases:
         metrics:
         - type: Object
           object:
-            metricName: mesmer_zip_consumer_key_ratio
-            target:
-              apiVersion: v1
+            describedObject:
               kind: Namespace
               name: mesmer_zip_consumer_key_ratio
-            targetValue: 1
+              apiVersion: v1
+            metric:
+              name: mesmer_zip_consumer_key_ratio
+            target:
+              type: Value
+              value: 1
 
       env:
         QUEUE: "mesmer"

--- a/conf/helmfile.d/0270.polaris-consumer.yaml
+++ b/conf/helmfile.d/0270.polaris-consumer.yaml
@@ -50,12 +50,15 @@ releases:
         metrics:
         - type: Object
           object:
-            metricName: polaris_consumer_key_ratio
-            target:
-              apiVersion: v1
+            describedObject:
               kind: Namespace
               name: polaris_consumer_key_ratio
-            targetValue: 1
+              apiVersion: v1
+            metric:
+              name: polaris_consumer_key_ratio
+            target:
+              type: Value
+              value: 1
 
       env:
         INTERVAL: 1

--- a/conf/helmfile.d/0271.polaris-zip-consumer.yaml
+++ b/conf/helmfile.d/0271.polaris-zip-consumer.yaml
@@ -50,12 +50,15 @@ releases:
         metrics:
         - type: Object
           object:
-            metricName: polaris_zip_consumer_key_ratio
-            target:
-              apiVersion: v1
+            describedObject:
               kind: Namespace
               name: polaris_zip_consumer_key_ratio
-            targetValue: 1
+              apiVersion: v1
+            metric:
+              name: polaris_zip_consumer_key_ratio
+            target:
+              type: Value
+              value: 1
 
       env:
         QUEUE: "polaris"

--- a/conf/helmfile.d/0280.spot-consumer.yaml
+++ b/conf/helmfile.d/0280.spot-consumer.yaml
@@ -50,12 +50,15 @@ releases:
         metrics:
         - type: Object
           object:
-            metricName: spot_consumer_key_ratio
-            target:
-              apiVersion: v1
+            describedObject:
               kind: Namespace
               name: spot_consumer_key_ratio
-            targetValue: 1
+              apiVersion: v1
+            metric:
+              name: spot_consumer_key_ratio
+            target:
+              type: Value
+              value: 1
 
       env:
         INTERVAL: 1

--- a/conf/helmfile.d/0281.spot-zip-consumer.yaml
+++ b/conf/helmfile.d/0281.spot-zip-consumer.yaml
@@ -50,12 +50,15 @@ releases:
         metrics:
         - type: Object
           object:
-            metricName: spot_zip_consumer_key_ratio
-            target:
-              apiVersion: v1
+            describedObject:
               kind: Namespace
               name: spot_zip_consumer_key_ratio
-            targetValue: 1
+              apiVersion: v1
+            metric:
+              name: spot_zip_consumer_key_ratio
+            target:
+              type: Value
+              value: 1
 
       env:
         QUEUE: "spot"

--- a/conf/helmfile.d/0300.frontend.yaml
+++ b/conf/helmfile.d/0300.frontend.yaml
@@ -74,7 +74,9 @@ releases:
         - type: Resource
           resource:
             name: cpu
-            targetAverageUtilization: 80
+            target:
+              type: Utilization
+              averageUtilization: 80
 
       env:
         PORT: 8080

--- a/conf/helmfile.d/0310.tf-serving.yaml
+++ b/conf/helmfile.d/0310.tf-serving.yaml
@@ -73,12 +73,15 @@ releases:
         metrics:
         - type: Object
           object:
-            metricName: tf_serving_gpu_usage
-            target:
-              apiVersion: v1
+            describedObject:
               kind: Namespace
               name: tf_serving_gpu_usage
-            targetValue: 70
+              apiVersion: v1
+            metric:
+              name: tf_serving_gpu_usage
+            target:
+              type: Value
+              value: 70
 
       annotations:
         prometheus.io/path: /monitoring/prometheus/metrics

--- a/conf/tasks/Makefile.gke
+++ b/conf/tasks/Makefile.gke
@@ -192,9 +192,9 @@ gke/create/service-account:
 	@echo "Creating GKE service account..."
 	@gcloud iam service-accounts create $(CLOUDSDK_CONTAINER_CLUSTER) --display-name "Deepcell" || \
 		echo "No need to create service account; it probably already exists."
-	@gcloud projects add-iam-policy-binding $(CLOUDSDK_CORE_PROJECT) --member serviceAccount:$(GCP_SERVICE_ACCOUNT) --role roles/storage.admin
+	@gcloud projects add-iam-policy-binding $(CLOUDSDK_CORE_PROJECT) --member serviceAccount:$(GCP_SERVICE_ACCOUNT) --role roles/storage.admin --no-user-output-enabled
 ifneq "" "${CERTIFICATE_MANAGER_ENABLED}"
-	@gcloud projects add-iam-policy-binding $(CLOUDSDK_CORE_PROJECT) --member serviceAccount:$(GCP_SERVICE_ACCOUNT) --role roles/dns.admin
+	@gcloud projects add-iam-policy-binding $(CLOUDSDK_CORE_PROJECT) --member serviceAccount:$(GCP_SERVICE_ACCOUNT) --role roles/dns.admin --no-user-output-enabled
 	# @gcloud iam service-accounts add-iam-policy-binding $(GCP_SERVICE_ACCOUNT) \
 	# 	--role roles/iam.workloadIdentityUser \
 	# 	--member "serviceAccount:$(CLOUDSDK_CORE_PROJECT).svc.id.goog[cert-manager/cert-manager]"
@@ -206,9 +206,9 @@ endif
 ## Delete Service Account used by deepcell
 gke/destroy/service-account:
 	@echo "Destroying GKE service-account..."
-	@gcloud projects remove-iam-policy-binding $(CLOUDSDK_CORE_PROJECT) --member serviceAccount:$(GCP_SERVICE_ACCOUNT) --role roles/storage.admin
+	@gcloud projects remove-iam-policy-binding $(CLOUDSDK_CORE_PROJECT) --member serviceAccount:$(GCP_SERVICE_ACCOUNT) --role roles/storage.admin --no-user-output-enabled
 ifneq "" "${CERTIFICATE_MANAGER_ENABLED}"
-	@gcloud projects remove-iam-policy-binding $(CLOUDSDK_CORE_PROJECT) --member serviceAccount:$(GCP_SERVICE_ACCOUNT) --role roles/dns.admin
+	@gcloud projects remove-iam-policy-binding $(CLOUDSDK_CORE_PROJECT) --member serviceAccount:$(GCP_SERVICE_ACCOUNT) --role roles/dns.admin --no-user-output-enabled
 endif
 	@-gcloud iam service-accounts delete $(GCP_SERVICE_ACCOUNT) --quiet
 	@echo "GKE service-account destruction finished."
@@ -244,6 +244,19 @@ gke/create/bucket:
 		|| echo "Bucket ${CLOUDSDK_BUCKET} already exists. No need to create that bucket."
 	@-gsutil acl ch -u $(GCP_SERVICE_ACCOUNT):O gs://$(CLOUDSDK_BUCKET)
 	@echo "Google Cloud Storage Bucket creation finished."
+	@echo " "
+	@echo " "
+
+## Install GKE Auth Plugin for kubectl
+gke/create/authplugin: INSTALL_AUTH_PLUGIN = $(shell echo ${USE_GKE_GCLOUD_AUTH_PLUGIN} | tr "[:upper:]" "[:lower:]")
+gke/create/authplugin:
+	@if [ "true" = "${INSTALL_AUTH_PLUGIN}" ]; then \
+		echo "Installing the GKE Auth Plugin..."; \
+		gcloud components install gke-gcloud-auth-plugin --quiet; \
+		echo "GKE Auth Plugin install complete."; \
+	else \
+		echo "GKE Auth Plugin is disabled."; \
+	fi
 	@echo " "
 	@echo " "
 
@@ -285,6 +298,7 @@ gke/create/resources: \
 
 ## Create Cluster
 gke/create/all: \
+	gke/create/authplugin \
 	gke/create/service-account \
 	gke/create/resources
 	@echo "GKE cluster created"

--- a/docs/source/GETTING_STARTED.rst
+++ b/docs/source/GETTING_STARTED.rst
@@ -114,7 +114,7 @@ You are now ready to start the Kiosk!
 
 .. code-block:: bash
 
-    docker run -e DOCKER_TAG=1.8.0 vanvalenlab/kiosk-console:1.8.0 | sudo bash
+    docker run -e DOCKER_TAG=1.8.1 vanvalenlab/kiosk-console:1.8.1 | sudo bash
 
 .. note:: This command and the one that follows may need to be preceded by `sudo` depending on your permission settings. This will require you to enter your password.
 

--- a/rootfs/etc/profile.d/banner.sh
+++ b/rootfs/etc/profile.d/banner.sh
@@ -4,17 +4,43 @@ COLOR_RESET="[0m"
 BANNER_COMMAND="${BANNER_COMMAND:-figurine}"
 BANNER_COLOR="${BANNER_COLOR:-[36m}"
 BANNER_INDENT="${BANNER_INDENT:-    }"
-BANNER_FONT="${BANNER_FONT:-Nancyj.flf}"
+BANNER_FONT="${BANNER_FONT:-Nancyj.flf}" # " IDE parser fix
 
 if [ "${SHLVL}" == "2" ]; then
-	# Display a banner message for interactive shells (if we're not in aws-vault or aws-okta)
-	if [ -n "${BANNER}" ]; then
-		if [ "$BANNER_COMMAND" == "figlet" ]; then
-			echo "${BANNER_COLOR}"
-			${BANNER_COMMAND} -w 200 "${BANNER}" | sed "s/^/${BANNER_INDENT}/"
-			echo "${COLOR_RESET}"
-		elif [ "$BANNER_COMMAND" == "figurine" ]; then
-			${BANNER_COMMAND} -f "${BANNER_FONT}" "${BANNER}" | sed "s/^/${BANNER_INDENT}/"
+	function _check_support() {
+		[[ $(arch) != "x86_64" ]] || grep -qsE 'GenuineIntel|AuthenticAMD' /proc/cpuinfo && return
+		yellow '# Detected Apple M1 emulating Intel CPU. Support for this configuration is evolving.'
+		yellow '# Report issues and read about solutions at https://github.com/cloudposse/geodesic/issues/719'
+	}
+
+	function _header() {
+		local vstring
+		local debian_version="/etc/debian_version"
+
+		# Development version of GEODESIC_VERSION might have version string
+		# like ' (0.143.1-7-g444f3c8/branch)' (note leading space)
+		# so we clean that up a bit
+		vstring=$(printf "%s" "${GEODESIC_VERSION}" | sed -E 's/^ ?\((.*)\)/\1/')
+		# Display a banner message for interactive shells (if we're not in aws-vault or aws-okta)
+		[ -n "${vstring}" ] && vstring=" version ${vstring}"
+		if source /etc/os-release; then
+			[[ -r $debian_version ]] && VERSION_ID=$(cat $debian_version)
+			printf "# Geodesic${vstring} based on %s (%s)\n\n" "$PRETTY_NAME" "$VERSION_ID"
 		fi
-	fi
+		if [ -n "${BANNER}" ]; then
+			if [ "$BANNER_COMMAND" == "figlet" ]; then
+				echo "${BANNER_COLOR}"
+				${BANNER_COMMAND} -w 200 "${BANNER}" | sed "s/^/${BANNER_INDENT}/"
+				echo "${COLOR_RESET}"
+			elif [ "$BANNER_COMMAND" == "figurine" ]; then
+				${BANNER_COMMAND} -f "${BANNER_FONT}" "${BANNER}" | sed "s/^/${BANNER_INDENT}/"
+			else
+				${BANNER_COMMAND}
+			fi
+		fi
+	}
+	_check_support
+	_header
+	unset _check_support
+	unset _header
 fi

--- a/rootfs/etc/profile.d/motd.sh
+++ b/rootfs/etc/profile.d/motd.sh
@@ -1,6 +1,6 @@
 # overriding https://github.com/cloudposse/geodesic/blob/master/rootfs/etc/profile.d/motd.sh
 
-if [[ -z "${ASSUME_ROLE}" && "${SHLVL}" == "2" ]]; then
+if [[ $SHLVL -eq 2 ]]; then
 	if [ -f "/etc/motd" ]; then
 		cat "/etc/motd"
 	fi

--- a/scripts/deploy-helmfiles.sh
+++ b/scripts/deploy-helmfiles.sh
@@ -6,7 +6,7 @@ retries=3
 
 for filename in /conf/helmfile.d/*.yaml; do
   deployment_names=$(helmfile -f $filename build | \
-                     yq r - -- releases[*].name | awk '{print $NF}')
+                     yq .releases[].name | awk '{print $NF}')
   for name in $deployment_names; do
     for ((i=0; i<retries; i++)); do
       # Try to deploy and break out of retry loop if successful


### PR DESCRIPTION
* chore: update geodesic to latest version.

Update some env vars and scripts too.

* fix: yq has new syntax

* feat: use new gke auth plugin to silence warnings.

* fix: update HPA API definition

* fix: drop MAKE_INCLUDES changes, confusing make

* chore: silence user output for IAM commands.

* fix: update HPA metrics for v2beta2 API.

* fix: only install plugin if it is enabled.

Disabled by default as the plugin is recommended but not required.