### PR TITLE
fix: update base images to upgrade `gcloud` and resolve auth issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM cloudposse/build-harness:1.3.0 as build-harness
+FROM cloudposse/build-harness:1.6.0 as build-harness
 
-FROM cloudposse/geodesic:1.2.1-alpine
+FROM cloudposse/geodesic:1.3.5-alpine
 
 RUN apk add --update dialog libqrencode
 

--- a/conf/tasks/Makefile.gke
+++ b/conf/tasks/Makefile.gke
@@ -9,8 +9,11 @@ export CLOUDSDK_CONFIG ?= /localhost/.config/gcloud/
 # Increase quotas: https://console.cloud.google.com/iam-admin/quotas
 
 ## Login to Google Cloud
+## setting all text to white as a workaround for readability issues in menu
 gke/login:
+	@tput setaf 7
 	@gcloud-login.sh
+	@tput sgr0
 
 ## Create a new project
 gke/create/project:


### PR DESCRIPTION
Upgrades base images to get `gcloud` to v401.0.0 which resolves the issue described in #468.

Also, adds some hacky workaround for a text readability issue I encountered on the auth step. Setting all text to white and resetting before/after the `gcloud-login.sh` script runs.

(Fixes #468)